### PR TITLE
GitHub ActionsでCIを行うワークフローファイルを追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: Flutter CI
+
+on:
+  pull_request:
+
+concurrency:
+  group: pr-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-on-ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version-file: "pubspec.yaml"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Build web
+        run: flutter build web
+
+      - name: Build android apk
+        run: flutter build apk
+
+  build-on-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version-file: "pubspec.yaml"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build ios
+        run: flutter build ios --no-codesign

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.9.0-196.1.beta <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.7.0 <4.0.0"
+  flutter: ">=3.32.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-196.1.beta
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: 3.32.4
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
## 概要

CI機能の追加

## 関連Issue

#4 

## 変更内容

下記のような内容のCIを行うワークフローファイルを追加

-- PR（プルリクエスト）が作成・更新されたときにCIを自動実行
- 同じPRで複数のCIが同時に走らないようにconcurrencyで制御
- Ubuntu環境で以下を実施
  - リポジトリのチェックアウト
  - Flutterのセットアップ
  - 依存パッケージのインストール
  - 静的解析（flutter analyze）
  - テスト実行（flutter test）
  - Webアプリのビルド
  - Android APKのビルド
- macOS環境で以下を実施
  - リポジトリのチェックアウト
  - Flutterのセットアップ
  - 依存パッケージのインストール
  - iOSアプリのビルド（署名なし）

## 動作確認内容

CIが通るかを確認

## 補足

特になし
