### PR TITLE
モック未実装箇所の追加実装

### DIFF
--- a/test/mock/mock_shared_preferences_async_plarform.dart
+++ b/test/mock/mock_shared_preferences_async_plarform.dart
@@ -24,54 +24,60 @@ final class MockSharedPreferencesAsyncPlatform
   Future<void> clear(
     ClearPreferencesParameters parameters,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement clear
-    throw UnimplementedError();
+  ) async {
+    _store.clear();
   }
 
   @override
-  Future<bool?> getBool(String key, SharedPreferencesOptions options) {
-    // TODO: implement getBool
-    throw UnimplementedError();
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
+    return _store[key] as bool?;
   }
 
   @override
-  Future<double?> getDouble(String key, SharedPreferencesOptions options) {
-    // TODO: implement getDouble
-    throw UnimplementedError();
+  Future<double?> getDouble(
+    String key,
+    SharedPreferencesOptions options,
+  ) async {
+    return _store[key] as double?;
   }
 
   @override
   Future<Set<String>> getKeys(
     GetPreferencesParameters parameters,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement getKeys
-    throw UnimplementedError();
+  ) async {
+    return _store.keys.toSet();
   }
 
   @override
   Future<Map<String, Object>> getPreferences(
     GetPreferencesParameters parameters,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement getPreferences
-    throw UnimplementedError();
+  ) async {
+    // Object? ではなく Object なので、null を除外
+    return Map<String, Object>.fromEntries(
+      _store.entries
+          .where((e) => e.value != null)
+          .map(
+            (e) => MapEntry(e.key, e.value!),
+          ),
+    );
   }
 
   @override
-  Future<String?> getString(String key, SharedPreferencesOptions options) {
-    // TODO: implement getString
-    throw UnimplementedError();
+  Future<String?> getString(
+    String key,
+    SharedPreferencesOptions options,
+  ) async {
+    return _store[key] as String?;
   }
 
   @override
   Future<List<String>?> getStringList(
     String key,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement getStringList
-    throw UnimplementedError();
+  ) async {
+    return _store[key] as List<String>?;
   }
 
   @override
@@ -79,9 +85,8 @@ final class MockSharedPreferencesAsyncPlatform
     String key,
     bool value,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement setBool
-    throw UnimplementedError();
+  ) async {
+    _store[key] = value;
   }
 
   @override
@@ -89,9 +94,8 @@ final class MockSharedPreferencesAsyncPlatform
     String key,
     double value,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement setDouble
-    throw UnimplementedError();
+  ) async {
+    _store[key] = value;
   }
 
   @override
@@ -99,9 +103,8 @@ final class MockSharedPreferencesAsyncPlatform
     String key,
     String value,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement setString
-    throw UnimplementedError();
+  ) async {
+    _store[key] = value;
   }
 
   @override
@@ -109,8 +112,7 @@ final class MockSharedPreferencesAsyncPlatform
     String key,
     List<String> value,
     SharedPreferencesOptions options,
-  ) {
-    // TODO: implement setStringList
-    throw UnimplementedError();
+  ) async {
+    _store[key] = value;
   }
 }


### PR DESCRIPTION
## 概要

MockSharedPreferencesAsyncPlatform の未実装箇所を実装した。

前回のPR時に実装しても良かったが、PR単位が大きくなりすぎてしまうので、最低限の実装を行なって分割した。

ここにその詳細を記す。

## 関連Issue

#23 

## 変更内容

MockSharedPreferencesAsyncPlatform の未実装箇所を実装

## 動作確認内容

- テストが通ること
- CIが通ること

## 補足（プロンプト）

---

### なぜモックが必要か

smsmsy: MockSharedPreferencesAsyncPlatform の実装における背景情報をここに記し、なぜこのような実装が必要か説明して下さい。

GitHub Copilot: `MockSharedPreferencesAsyncPlatform` の実装は、Flutterアプリのテストにおいて `shared_preferences` パッケージの非同期プラットフォームインターフェースをモック（擬似実装）するために必要です。

### 背景
- `shared_preferences` は、アプリ内で簡易的なデータ保存（キー・バリュー形式）を行うためのパッケージです。
- 実際のプラットフォーム（iOS/Androidなど）に依存してデータを永続化するため、テスト環境では本物のストレージにアクセスできません。
- テスト時に本物のストレージを使うと、テストの再現性が損なわれたり、意図しない副作用が発生する可能性があります。

### なぜこの実装が必要か
- テスト環境で `shared_preferences` のAPIを呼び出しても、実際のデータ保存・取得が行われないようにするため。
- モック実装を使うことで、テストごとに状態をリセットでき、テストの独立性・再現性が保たれます。
- 非同期API（Futureを返すメソッド）に対応したモックが必要なため、`MockSharedPreferencesAsyncPlatform` を独自に実装します。

### まとめ
`MockSharedPreferencesAsyncPlatform` は、`shared_preferences` の非同期APIをテスト用に安全に置き換えるためのモック実装であり、テストの信頼性と再現性を確保するために不可欠です。

---

### どのように実装したか

`throw UnimplementedError();` となっている未実装箇所を、`_store` を使ったメモリ上でのモック実装に書き換えます。  
各型ごとに値の保存・取得、全削除、全取得などを適切に実装します。  
これにより、テスト時に `shared_preferences` のAPIを安全に利用できるようになります。

修正を行います。 
````

````


変更を行いました。

`getKeys` のシグネチャが親クラスと一致していないため、エラーが発生しています。  
`Future<Set<String>> getKeys(GetPreferencesParameters parameters, SharedPreferencesOptions options)` のみを受け取る形に修正します。

この修正を行います。 
````

````


変更を行いました。

`throw UnimplementedError();` となっていた未実装部分を、すべてメモリ上のモックとして実装しました。また、`getKeys` のシグネチャも正しく修正しました。

これで `MockSharedPreferencesAsyncPlatform` はテスト用のモックとして正常に動作します。追加のご要望があればお知らせください。