### PR TITLE
ThemeDataのベースとしてのcustomThemeDataProviderを作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_flutter_engineer_codecheck/provider/custom_theme_data_provider.dart';
 import 'package:yumemi_flutter_engineer_codecheck/provider/selected_theme_mode_provider.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/theme_mode_select_button.dart';
 
@@ -16,15 +17,8 @@ class MyApp extends ConsumerWidget {
     final themeMode = ref.watch(selectedThemeModeProvider);
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.deepPurple,
-          brightness: Brightness.dark,
-        ),
-      ),
+      theme: ref.watch(customThemeDataProvider(Brightness.light)),
+      darkTheme: ref.watch(customThemeDataProvider(Brightness.dark)),
       themeMode: themeMode.value ?? ThemeMode.system,
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
@@ -59,7 +53,6 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(widget.title),
         actions: const [
           ThemeModeSelectButton(),

--- a/lib/provider/custom_theme_data_provider.dart
+++ b/lib/provider/custom_theme_data_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final ProviderFamily<ThemeData, Brightness> customThemeDataProvider =
+    Provider.family<ThemeData, Brightness>(
+      (ref, brightness) {
+        return ThemeData(
+          useMaterial3: true,
+          colorScheme: ColorScheme.fromSeed(
+            brightness: brightness,
+            seedColor: const Color(0xFF1158c7),
+          ),
+        );
+      },
+    );


### PR DESCRIPTION
## 概要

アプリ全体で適用するThemeDataを簡単に管理するためのプロバイダーを作成した

## 関連Issue

#15 

## 変更内容

- ThemeDataのベースとしてのcustomThemeDataProviderを作成
- `main.dart` に適用

## 動作確認内容

### Before - After

<img height="300" alt="スクリーンショット 2025-06-21 15 39 22" src="https://github.com/user-attachments/assets/c253c185-095a-47fa-9ee4-5d43914de36b" />
<img height="300" alt="スクリーンショット 2025-06-21 15 40 18" src="https://github.com/user-attachments/assets/148bb341-56ed-4261-b1ab-cb5ca8990504" />

------------------------ 👇 ------------------------

<img height="300" alt="スクリーンショット 2025-06-21 15 41 27" src="https://github.com/user-attachments/assets/30e70389-73db-4bee-9b7a-906308edcbdc" />
<img height="300" alt="スクリーンショット 2025-06-21 15 41 37" src="https://github.com/user-attachments/assets/b7a6806b-cef9-4ce1-9764-93de24071c44" />


## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
