### PR TITLE
ルーティング対応

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/provider/custom_theme_data_provider.dart';
+import 'package:yumemi_flutter_engineer_codecheck/provider/go_router_provider.dart';
 import 'package:yumemi_flutter_engineer_codecheck/provider/selected_theme_mode_provider.dart';
-import 'package:yumemi_flutter_engineer_codecheck/view/widget/theme_mode_select_button.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));
@@ -15,61 +15,14 @@ class MyApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(selectedThemeModeProvider);
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Flutter Demo',
       theme: ref.watch(customThemeDataProvider(Brightness.light)),
       darkTheme: ref.watch(customThemeDataProvider(Brightness.dark)),
       themeMode: themeMode.value ?? ThemeMode.system,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const MyHomePage(),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key});
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  var _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final localizations = AppLocalizations.of(context)!;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(localizations.homePageTitle),
-        actions: const [
-          ThemeModeSelectButton(),
-        ],
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(localizations.counterText),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: localizations.incrementTooltip,
-        child: const Icon(Icons.add),
-      ),
+      routerConfig: ref.watch(goRouterProvider),
     );
   }
 }

--- a/lib/provider/go_router_provider.dart
+++ b/lib/provider/go_router_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/my_home_page.dart';
+
+final goRouterProvider = Provider<GoRouter>(
+  (ref) => createGoRouter(),
+);
+
+class AppRoutes {
+  static const root = '/';
+}
+
+GoRouter createGoRouter() {
+  return GoRouter(
+    routes: [
+      GoRoute(
+        path: AppRoutes.root,
+        name: 'home',
+        builder: (context, state) => const MyHomePage(),
+      ),
+    ],
+  );
+}

--- a/lib/view/page/my_home_page.dart
+++ b/lib/view/page/my_home_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/theme_mode_select_button.dart';
+
+class MyHomePage extends ConsumerStatefulWidget {
+  const MyHomePage({super.key});
+
+  @override
+  ConsumerState<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends ConsumerState<MyHomePage> {
+  var _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(localizations?.homePageTitle ?? 'Home Page'),
+        actions: const [
+          ThemeModeSelectButton(),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              localizations?.counterText ??
+                  'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: localizations?.incrementTooltip ?? 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -317,6 +317,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "02ff498f6279470ff7f60c998a69b872f26696ceec237c8402e63a2133868ddf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.3"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.6.1
+  go_router: ^15.2.3
   intl: ^0.20.2
   riverpod_annotation: ^2.6.1
   shared_preferences: ^2.5.3


### PR DESCRIPTION
## 概要

画面追加に対するアプリの拡張に耐えられるように go_router によるルーティング機能を追加する

## 関連Issue

#17 

## 変更内容

- **lib/main.dart**
  - ルーティングを `MaterialApp.router` + `go_router` に変更
  - `go_router_provider` の導入
  - `MyHomePage` の定義を削除し、外部ファイル化
- **lib/provider/go_router_provider.dart**（新規追加）
  - `GoRouter` を提供する `goRouterProvider` を追加
  - ルート定義（`/` → `MyHomePage`）
- **lib/view/page/my_home_page.dart**（新規追加）
  - `MyHomePage` ウィジェットを新規作成
  - カウンター機能やテーマ切替ボタンを含む
- **pubspec.yaml**, **pubspec.lock**
  - `go_router` パッケージを依存関係に追加

## 動作確認内容

- アプリを起動し問題なく動作することを確認
- テストが問題なく通ること
  - 普通に通ったのは意外だった

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
