### PR TITLE
Feature/oss license view

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -14,5 +14,9 @@
   "incrementTooltip": "Increment",
   "@incrementTooltip": {
     "description": "Tooltip for the increment button."
+  },
+  "ossLicense": "OSS License",
+  "@ossLicense": {
+    "description": "The license information for the app."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2,5 +2,6 @@
   "appTitle": "フラッターデモ",
   "homePageTitle": "フラッターデモホームページ",
   "counterText": "ボタンを押した回数:",
-  "incrementTooltip": "増やす"
+  "incrementTooltip": "増やす",
+  "ossLicense": "OSSライセンス"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -121,6 +121,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Increment'**
   String get incrementTooltip;
+
+  /// The license information for the app.
+  ///
+  /// In en, this message translates to:
+  /// **'OSS License'**
+  String get ossLicense;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -19,4 +19,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get incrementTooltip => 'Increment';
+
+  @override
+  String get ossLicense => 'OSS License';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -19,4 +19,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get incrementTooltip => '増やす';
+
+  @override
+  String get ossLicense => 'OSSライセンス';
 }

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -3,3 +3,4 @@ appTitle,The title of the application.,Flutter Demo,フラッターデモ
 homePageTitle,The title of the home page.,Flutter Demo Home Page,フラッターデモホームページ
 counterText,Label for the counter display.,You have pushed the button this many times:,ボタンを押した回数:
 incrementTooltip,Tooltip for the increment button.,Increment,増やす
+ossLicense,The license information for the app.,OSS License,OSSライセンス

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -1,0 +1,13 @@
+class WordingData {
+  static const applicationName = 'Yumemi Flutter Engineer Codecheck';
+
+  static const appTitle = 'Flutter Demo';
+
+  static const homePageTitle = 'Flutter Demo Home Page';
+
+  static const counterText = 'You have pushed the button this many times:';
+
+  static const incrementTooltip = 'Increment';
+
+  static const ossLicense = 'OSS License';
+}

--- a/lib/view/page/my_home_page.dart
+++ b/lib/view/page/my_home_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/custom_drawer.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/theme_mode_select_button.dart';
 
 class MyHomePage extends ConsumerStatefulWidget {
@@ -29,13 +31,13 @@ class _MyHomePageState extends ConsumerState<MyHomePage> {
           ThemeModeSelectButton(),
         ],
       ),
+      drawer: const CustomDrawer(),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             Text(
-              localizations?.counterText ??
-                  'You have pushed the button this many times:',
+              localizations?.counterText ?? WordingData.counterText,
             ),
             Text(
               '$_counter',
@@ -46,7 +48,8 @@ class _MyHomePageState extends ConsumerState<MyHomePage> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,
-        tooltip: localizations?.incrementTooltip ?? 'Increment',
+        tooltip:
+            localizations?.incrementTooltip ?? WordingData.incrementTooltip,
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/view/widget/custom_drawer.dart
+++ b/lib/view/widget/custom_drawer.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+
+class CustomDrawer extends StatelessWidget {
+  const CustomDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: <Widget>[
+          ListTile(
+            title: Text(
+              AppLocalizations.of(context)?.ossLicense ??
+                  WordingData.ossLicense,
+            ),
+            onTap: () {
+              showLicensePage(
+                context: context,
+                applicationName: WordingData.applicationName,
+                applicationVersion: '1.0.0',
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/view/my_home_page_drawer_test.dart
+++ b/test/view/my_home_page_drawer_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/my_home_page.dart';
+
+import '../mock/mock_shared_preferences_async_plarform.dart';
+
+void main() {
+  group('MyHomePage Drawer', () {
+    setUp(() {
+      SharedPreferencesAsyncPlatform.instance =
+          MockSharedPreferencesAsyncPlatform();
+    });
+
+    Future<void> pumpApp(WidgetTester tester, Locale locale) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            locale: locale,
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [
+              Locale('en'),
+              Locale('ja'),
+            ],
+            home: const MyHomePage(),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('DrawerにOSSライセンス(ja)が表示される', (tester) async {
+      await pumpApp(tester, const Locale('ja'));
+      // Drawerを開く
+      await tester.tap(find.byIcon(Icons.menu));
+      await tester.pumpAndSettle();
+      // OSSライセンスが表示されていることを確認
+      expect(find.text('OSSライセンス'), findsOneWidget);
+    });
+
+    testWidgets('DrawerにOSS License(en)が表示される', (tester) async {
+      await pumpApp(tester, const Locale('en'));
+      // Drawerを開く
+      await tester.tap(find.byIcon(Icons.menu));
+      await tester.pumpAndSettle();
+      // OSS Licenseが表示されていることを確認
+      expect(find.text('OSS License'), findsOneWidget);
+    });
+
+    testWidgets('Licensesのページが表示され元のページにも遷移することができる', (tester) async {
+      await pumpApp(tester, const Locale('en'));
+
+      // Drawerを開く
+      await tester.tap(find.byIcon(Icons.menu));
+      await tester.pumpAndSettle();
+
+      // OSS Licenseをタップ
+      await tester.tap(find.text('OSS License'));
+      await tester.pumpAndSettle();
+
+      // Licensesのページが表示されていることを確認
+      expect(find.text('Licenses'), findsOneWidget);
+      expect(find.byIcon(Icons.menu), findsNothing);
+
+      // 戻るボタンをタップして元のページに戻る
+      await tester.tap(find.byTooltip('Back'));
+      await tester.pumpAndSettle();
+
+      // 元のページに戻っていることを確認
+      expect(find.byIcon(Icons.menu), findsOneWidget);
+      expect(find.text('Licenses'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

OSSライセンス表示対応を行なった

## 関連Issue

#16 

## 変更内容

### 文言追加（OSS License / OSSライセンス）
-  lib/l10n/app_en.arb
-  lib/l10n/app_ja.arb
-  lib/l10n/app_localizations.dart
-  lib/l10n/app_localizations_en.dart
-  lib/l10n/app_localizations_ja.dart
-  lib/l10n/app_localizations_en.dart
-  lib/l10n/app_localizations_ja.dart
-  lib/l10n/strings.csv

### lib/static/wording_data.dart
- 新規ファイル
- アプリ内で使う文言（appTitle, homePageTitle, counterText, incrementTooltip, ossLicense など）を定数として定義

### lib/view/page/my_home_page.dart
- `WordingData` と `CustomDrawer` のimport追加
- `drawer: const CustomDrawer()` をScaffoldに追加
- カウンター文言・ツールチップのデフォルト値を `WordingData` の定数に変更

### lib/view/widget/custom_drawer.dart
- 新規ファイル
- OSSライセンスページを表示するDrawerウィジェットを追加
- Drawer内で `AppLocalizations` もしくは `WordingData` の `ossLicense` を表示
- タップで `showLicensePage` を呼び出し、アプリ名やバージョンを表示


## 動作確認内容

- ダークモード・ライトモードでの表示内容確認

<img width="339" alt="スクリーンショット 2025-06-21 20 52 23" src="https://github.com/user-attachments/assets/5d097333-16aa-4667-bb55-186013ac0fec" />

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
