### PR TITLE
 GitHub Search API で使用するモデルの定義

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ flutter pub get
 flutter run
 ```
 
-## Riverpod の自動生成
+## Riverpod/Freezed/JsonSerialization の自動生成
 
-Riverpod のコード自動生成には下記コマンドを使用してください。
+上記のようなbuild_runnerによるコード自動生成を実行するには下記コマンドを使用してください。
 
 ```terminal
 flutter pub run build_runner watch --delete-conflicting-outputs

--- a/lib/domain/model/git_hub_search_api/owner.dart
+++ b/lib/domain/model/git_hub_search_api/owner.dart
@@ -1,0 +1,15 @@
+// ignore_for_file: invalid_annotation_target, document_ignores
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'owner.freezed.dart';
+part 'owner.g.dart';
+
+@freezed
+sealed class Owner with _$Owner {
+  const factory Owner({
+    @JsonKey(name: 'avatar_url') required String avatarUrl,
+  }) = _Owner;
+
+  factory Owner.fromJson(Map<String, dynamic> json) => _$OwnerFromJson(json);
+}

--- a/lib/domain/model/git_hub_search_api/owner.freezed.dart
+++ b/lib/domain/model/git_hub_search_api/owner.freezed.dart
@@ -1,0 +1,148 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'owner.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Owner {
+
+@JsonKey(name: 'avatar_url') String get avatarUrl;
+/// Create a copy of Owner
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$OwnerCopyWith<Owner> get copyWith => _$OwnerCopyWithImpl<Owner>(this as Owner, _$identity);
+
+  /// Serializes this Owner to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Owner&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,avatarUrl);
+
+@override
+String toString() {
+  return 'Owner(avatarUrl: $avatarUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $OwnerCopyWith<$Res>  {
+  factory $OwnerCopyWith(Owner value, $Res Function(Owner) _then) = _$OwnerCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'avatar_url') String avatarUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$OwnerCopyWithImpl<$Res>
+    implements $OwnerCopyWith<$Res> {
+  _$OwnerCopyWithImpl(this._self, this._then);
+
+  final Owner _self;
+  final $Res Function(Owner) _then;
+
+/// Create a copy of Owner
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? avatarUrl = null,}) {
+  return _then(_self.copyWith(
+avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _Owner implements Owner {
+  const _Owner({@JsonKey(name: 'avatar_url') required this.avatarUrl});
+  factory _Owner.fromJson(Map<String, dynamic> json) => _$OwnerFromJson(json);
+
+@override@JsonKey(name: 'avatar_url') final  String avatarUrl;
+
+/// Create a copy of Owner
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$OwnerCopyWith<_Owner> get copyWith => __$OwnerCopyWithImpl<_Owner>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$OwnerToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Owner&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,avatarUrl);
+
+@override
+String toString() {
+  return 'Owner(avatarUrl: $avatarUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$OwnerCopyWith<$Res> implements $OwnerCopyWith<$Res> {
+  factory _$OwnerCopyWith(_Owner value, $Res Function(_Owner) _then) = __$OwnerCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'avatar_url') String avatarUrl
+});
+
+
+
+
+}
+/// @nodoc
+class __$OwnerCopyWithImpl<$Res>
+    implements _$OwnerCopyWith<$Res> {
+  __$OwnerCopyWithImpl(this._self, this._then);
+
+  final _Owner _self;
+  final $Res Function(_Owner) _then;
+
+/// Create a copy of Owner
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? avatarUrl = null,}) {
+  return _then(_Owner(
+avatarUrl: null == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/domain/model/git_hub_search_api/owner.g.dart
+++ b/lib/domain/model/git_hub_search_api/owner.g.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'owner.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Owner _$OwnerFromJson(Map<String, dynamic> json) =>
+    _Owner(avatarUrl: json['avatar_url'] as String);
+
+Map<String, dynamic> _$OwnerToJson(_Owner instance) => <String, dynamic>{
+  'avatar_url': instance.avatarUrl,
+};

--- a/lib/domain/model/git_hub_search_api/repository.dart
+++ b/lib/domain/model/git_hub_search_api/repository.dart
@@ -1,0 +1,25 @@
+// ignore_for_file: invalid_annotation_target, document_ignores
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
+
+part 'repository.freezed.dart';
+part 'repository.g.dart';
+
+/// GitHub Search API のレスポンスモデル
+@freezed
+sealed class Repository with _$Repository {
+  @JsonSerializable(explicitToJson: true)
+  const factory Repository({
+    required String name,
+    required Owner owner,
+    required String language,
+    @JsonKey(name: 'stargazers_count') required int stargazersCount,
+    @JsonKey(name: 'watchers_count') required int watchersCount,
+    @JsonKey(name: 'forks_count') required int forksCount,
+    @JsonKey(name: 'open_issues_count') required int openIssuesCount,
+  }) = _Repository;
+
+  factory Repository.fromJson(Map<String, dynamic> json) =>
+      _$RepositoryFromJson(json);
+}

--- a/lib/domain/model/git_hub_search_api/repository.freezed.dart
+++ b/lib/domain/model/git_hub_search_api/repository.freezed.dart
@@ -1,0 +1,184 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'repository.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Repository {
+
+ String get name; Owner get owner; String get language;@JsonKey(name: 'stargazers_count') int get stargazersCount;@JsonKey(name: 'watchers_count') int get watchersCount;@JsonKey(name: 'forks_count') int get forksCount;@JsonKey(name: 'open_issues_count') int get openIssuesCount;
+/// Create a copy of Repository
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RepositoryCopyWith<Repository> get copyWith => _$RepositoryCopyWithImpl<Repository>(this as Repository, _$identity);
+
+  /// Serializes this Repository to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Repository&&(identical(other.name, name) || other.name == name)&&(identical(other.owner, owner) || other.owner == owner)&&(identical(other.language, language) || other.language == language)&&(identical(other.stargazersCount, stargazersCount) || other.stargazersCount == stargazersCount)&&(identical(other.watchersCount, watchersCount) || other.watchersCount == watchersCount)&&(identical(other.forksCount, forksCount) || other.forksCount == forksCount)&&(identical(other.openIssuesCount, openIssuesCount) || other.openIssuesCount == openIssuesCount));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,owner,language,stargazersCount,watchersCount,forksCount,openIssuesCount);
+
+@override
+String toString() {
+  return 'Repository(name: $name, owner: $owner, language: $language, stargazersCount: $stargazersCount, watchersCount: $watchersCount, forksCount: $forksCount, openIssuesCount: $openIssuesCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RepositoryCopyWith<$Res>  {
+  factory $RepositoryCopyWith(Repository value, $Res Function(Repository) _then) = _$RepositoryCopyWithImpl;
+@useResult
+$Res call({
+ String name, Owner owner, String language,@JsonKey(name: 'stargazers_count') int stargazersCount,@JsonKey(name: 'watchers_count') int watchersCount,@JsonKey(name: 'forks_count') int forksCount,@JsonKey(name: 'open_issues_count') int openIssuesCount
+});
+
+
+$OwnerCopyWith<$Res> get owner;
+
+}
+/// @nodoc
+class _$RepositoryCopyWithImpl<$Res>
+    implements $RepositoryCopyWith<$Res> {
+  _$RepositoryCopyWithImpl(this._self, this._then);
+
+  final Repository _self;
+  final $Res Function(Repository) _then;
+
+/// Create a copy of Repository
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? owner = null,Object? language = null,Object? stargazersCount = null,Object? watchersCount = null,Object? forksCount = null,Object? openIssuesCount = null,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,owner: null == owner ? _self.owner : owner // ignore: cast_nullable_to_non_nullable
+as Owner,language: null == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String,stargazersCount: null == stargazersCount ? _self.stargazersCount : stargazersCount // ignore: cast_nullable_to_non_nullable
+as int,watchersCount: null == watchersCount ? _self.watchersCount : watchersCount // ignore: cast_nullable_to_non_nullable
+as int,forksCount: null == forksCount ? _self.forksCount : forksCount // ignore: cast_nullable_to_non_nullable
+as int,openIssuesCount: null == openIssuesCount ? _self.openIssuesCount : openIssuesCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+/// Create a copy of Repository
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$OwnerCopyWith<$Res> get owner {
+  
+  return $OwnerCopyWith<$Res>(_self.owner, (value) {
+    return _then(_self.copyWith(owner: value));
+  });
+}
+}
+
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _Repository implements Repository {
+  const _Repository({required this.name, required this.owner, required this.language, @JsonKey(name: 'stargazers_count') required this.stargazersCount, @JsonKey(name: 'watchers_count') required this.watchersCount, @JsonKey(name: 'forks_count') required this.forksCount, @JsonKey(name: 'open_issues_count') required this.openIssuesCount});
+  factory _Repository.fromJson(Map<String, dynamic> json) => _$RepositoryFromJson(json);
+
+@override final  String name;
+@override final  Owner owner;
+@override final  String language;
+@override@JsonKey(name: 'stargazers_count') final  int stargazersCount;
+@override@JsonKey(name: 'watchers_count') final  int watchersCount;
+@override@JsonKey(name: 'forks_count') final  int forksCount;
+@override@JsonKey(name: 'open_issues_count') final  int openIssuesCount;
+
+/// Create a copy of Repository
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RepositoryCopyWith<_Repository> get copyWith => __$RepositoryCopyWithImpl<_Repository>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RepositoryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Repository&&(identical(other.name, name) || other.name == name)&&(identical(other.owner, owner) || other.owner == owner)&&(identical(other.language, language) || other.language == language)&&(identical(other.stargazersCount, stargazersCount) || other.stargazersCount == stargazersCount)&&(identical(other.watchersCount, watchersCount) || other.watchersCount == watchersCount)&&(identical(other.forksCount, forksCount) || other.forksCount == forksCount)&&(identical(other.openIssuesCount, openIssuesCount) || other.openIssuesCount == openIssuesCount));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,owner,language,stargazersCount,watchersCount,forksCount,openIssuesCount);
+
+@override
+String toString() {
+  return 'Repository(name: $name, owner: $owner, language: $language, stargazersCount: $stargazersCount, watchersCount: $watchersCount, forksCount: $forksCount, openIssuesCount: $openIssuesCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RepositoryCopyWith<$Res> implements $RepositoryCopyWith<$Res> {
+  factory _$RepositoryCopyWith(_Repository value, $Res Function(_Repository) _then) = __$RepositoryCopyWithImpl;
+@override @useResult
+$Res call({
+ String name, Owner owner, String language,@JsonKey(name: 'stargazers_count') int stargazersCount,@JsonKey(name: 'watchers_count') int watchersCount,@JsonKey(name: 'forks_count') int forksCount,@JsonKey(name: 'open_issues_count') int openIssuesCount
+});
+
+
+@override $OwnerCopyWith<$Res> get owner;
+
+}
+/// @nodoc
+class __$RepositoryCopyWithImpl<$Res>
+    implements _$RepositoryCopyWith<$Res> {
+  __$RepositoryCopyWithImpl(this._self, this._then);
+
+  final _Repository _self;
+  final $Res Function(_Repository) _then;
+
+/// Create a copy of Repository
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? owner = null,Object? language = null,Object? stargazersCount = null,Object? watchersCount = null,Object? forksCount = null,Object? openIssuesCount = null,}) {
+  return _then(_Repository(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,owner: null == owner ? _self.owner : owner // ignore: cast_nullable_to_non_nullable
+as Owner,language: null == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String,stargazersCount: null == stargazersCount ? _self.stargazersCount : stargazersCount // ignore: cast_nullable_to_non_nullable
+as int,watchersCount: null == watchersCount ? _self.watchersCount : watchersCount // ignore: cast_nullable_to_non_nullable
+as int,forksCount: null == forksCount ? _self.forksCount : forksCount // ignore: cast_nullable_to_non_nullable
+as int,openIssuesCount: null == openIssuesCount ? _self.openIssuesCount : openIssuesCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+/// Create a copy of Repository
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$OwnerCopyWith<$Res> get owner {
+  
+  return $OwnerCopyWith<$Res>(_self.owner, (value) {
+    return _then(_self.copyWith(owner: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/domain/model/git_hub_search_api/repository.g.dart
+++ b/lib/domain/model/git_hub_search_api/repository.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'repository.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Repository _$RepositoryFromJson(Map<String, dynamic> json) => _Repository(
+  name: json['name'] as String,
+  owner: Owner.fromJson(json['owner'] as Map<String, dynamic>),
+  language: json['language'] as String,
+  stargazersCount: (json['stargazers_count'] as num).toInt(),
+  watchersCount: (json['watchers_count'] as num).toInt(),
+  forksCount: (json['forks_count'] as num).toInt(),
+  openIssuesCount: (json['open_issues_count'] as num).toInt(),
+);
+
+Map<String, dynamic> _$RepositoryToJson(_Repository instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'owner': instance.owner.toJson(),
+      'language': instance.language,
+      'stargazers_count': instance.stargazersCount,
+      'watchers_count': instance.watchersCount,
+      'forks_count': instance.forksCount,
+      'open_issues_count': instance.openIssuesCount,
+    };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,8 +293,16 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
@@ -390,13 +398,21 @@ packages:
     source: hosted
     version: "0.7.2"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -682,6 +698,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.5"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,10 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.6.1
+  freezed_annotation: ^3.0.0
   go_router: ^15.2.3
   intl: ^0.20.2
+  json_annotation: ^4.9.0
   riverpod_annotation: ^2.6.1
   shared_preferences: ^2.5.3
   simple_logger: ^1.9.0
@@ -25,6 +27,8 @@ dev_dependencies:
   custom_lint: ^0.7.5
   flutter_test:
     sdk: flutter
+  freezed: ^3.0.6
+  json_serializable: ^6.9.5
   riverpod_generator: ^2.6.5
   riverpod_lint: ^2.6.5
   shared_preferences_platform_interface: ^2.4.1

--- a/test/domain/model/git_hub_search_api/repository_test.dart
+++ b/test/domain/model/git_hub_search_api/repository_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+
+void main() {
+  const response = Repository(
+    name: 'flutter',
+    owner: Owner(
+      avatarUrl: 'https://avatars.githubusercontent.com/u/14101776?v=4',
+    ),
+    language: 'dart',
+    stargazersCount: 3000,
+    watchersCount: 2000,
+    forksCount: 200,
+    openIssuesCount: 350,
+  );
+
+  const json = {
+    'name': 'flutter',
+    'owner': {
+      'avatar_url': 'https://avatars.githubusercontent.com/u/14101776?v=4',
+    },
+    'language': 'dart',
+    'stargazers_count': 3000,
+    'watchers_count': 2000,
+    'forks_count': 200,
+    'open_issues_count': 350,
+  };
+
+  group('GitHubリポジトリ検索APIのモデルに関するテスト', () {
+    test('基本的な確認', () {
+      expect(response.name, 'flutter');
+      expect(
+        response.owner.avatarUrl,
+        'https://avatars.githubusercontent.com/u/14101776?v=4',
+      );
+      expect(response.language, 'dart');
+      expect(response.stargazersCount, 3000);
+      expect(response.watchersCount, 2000);
+      expect(response.forksCount, 200);
+      expect(response.openIssuesCount, 350);
+    });
+  });
+
+  test('fromJsonの確認', () {
+    final response = Repository.fromJson(json);
+
+    expect(response.name, 'flutter');
+    expect(
+      response.owner.avatarUrl,
+      'https://avatars.githubusercontent.com/u/14101776?v=4',
+    );
+    expect(response.language, 'dart');
+    expect(response.stargazersCount, 3000);
+    expect(response.watchersCount, 2000);
+    expect(response.forksCount, 200);
+    expect(response.openIssuesCount, 350);
+  });
+
+  test('toJsonの確認', () {
+    final jsonResponse = response.toJson();
+    expect(jsonResponse['name'], 'flutter');
+    expect(
+      (jsonResponse['owner'] as Map<String, dynamic>)['avatar_url'],
+      'https://avatars.githubusercontent.com/u/14101776?v=4',
+    );
+    expect(jsonResponse['language'], 'dart');
+    expect(jsonResponse['stargazers_count'], 3000);
+    expect(jsonResponse['watchers_count'], 2000);
+    expect(jsonResponse['forks_count'], 200);
+    expect(jsonResponse['open_issues_count'], 350);
+  });
+}


### PR DESCRIPTION
## 概要

 GitHub Search API で使用するモデルの定義

## 関連Issue

#40 

## 変更内容

### ドキュメント・自動生成コマンド説明の修正
- README.md
  - build_runnerによる自動生成コマンドの説明を「Riverpod」から「Riverpod/Freezed/JsonSerialization」に拡張し、説明文をより汎用的に修正。

### GitHub Search API モデルの新規追加
- lib/domain/model/git_hub_search_api/owner.dart
  - GitHubリポジトリのオーナー情報（avatar_urlのみ）を表す`Owner`モデルをFreezed/JsonSerializableで新規

## 動作確認内容

単体テストで書きを確認
- パラメータが正しく使用できること
- fromJson/toJsonが正しく使用できること

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
