### PR TITLE
検索テキストボックスの実装

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -26,5 +26,9 @@
   "themeModeSelect": "Select Theme Mode",
   "@themeModeSelect": {
     "description": "The label for selecting theme mode."
+  },
+  "searchRepositories": "Search repositories",
+  "@searchRepositories": {
+    "description": "The label for searching repositories."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -5,5 +5,6 @@
   "themeModeSystem": "システム",
   "themeModeLight": "ライト",
   "themeModeDark": "ダーク",
-  "themeModeSelect": "テーマモードを選択"
+  "themeModeSelect": "テーマモードを選択",
+  "searchRepositories": "リポジトリを検索"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -139,6 +139,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Select Theme Mode'**
   String get themeModeSelect;
+
+  /// The label for searching repositories.
+  ///
+  /// In en, this message translates to:
+  /// **'Search repositories'**
+  String get searchRepositories;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -28,4 +28,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get themeModeSelect => 'Select Theme Mode';
+
+  @override
+  String get searchRepositories => 'Search repositories';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -28,4 +28,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get themeModeSelect => 'テーマモードを選択';
+
+  @override
+  String get searchRepositories => 'リポジトリを検索';
 }

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -6,3 +6,4 @@ themeModeSystem,The label for system theme mode.,System,システム
 themeModeLight,The label for light theme mode.,Light,ライト
 themeModeDark,The label for dark theme mode.,Dark,ダーク
 themeModeSelect,The label for selecting theme mode.,Select Theme Mode,テーマモードを選択
+searchRepositories,The label for searching repositories.,Search repositories,リポジトリを検索

--- a/lib/provider/custom_theme_data_provider.dart
+++ b/lib/provider/custom_theme_data_provider.dart
@@ -4,11 +4,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final ProviderFamily<ThemeData, Brightness> customThemeDataProvider =
     Provider.family<ThemeData, Brightness>(
       (ref, brightness) {
+        final colorScheme = ColorScheme.fromSeed(
+          brightness: brightness,
+          seedColor: const Color(0xFF1158c7),
+        );
         return ThemeData(
           useMaterial3: true,
-          colorScheme: ColorScheme.fromSeed(
-            brightness: brightness,
-            seedColor: const Color(0xFF1158c7),
+          colorScheme: colorScheme,
+          inputDecorationTheme: InputDecorationTheme(
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+            prefixIconColor: WidgetStateColor.resolveWith((states) {
+              if (states.contains(WidgetState.focused)) {
+                return colorScheme.primary;
+              }
+              return colorScheme.secondary;
+            }),
           ),
         );
       },

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -14,4 +14,6 @@ class WordingData {
   static const themeModeDark = 'Dark';
 
   static const themeModeSelect = 'Select Theme Mode';
+
+  static const searchRepositories = 'Search repositories';
 }

--- a/lib/view/page/search_page.dart
+++ b/lib/view/page/search_page.dart
@@ -1,10 +1,21 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/custom_drawer.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/search_text_field.dart';
 
-class SearchPage extends StatelessWidget {
+class SearchPage extends StatefulWidget {
   const SearchPage({super.key});
+
+  @override
+  State<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  var _text = '';
+
+  final controller = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -16,6 +27,42 @@ class SearchPage extends StatelessWidget {
         ),
       ),
       drawer: const CustomDrawer(),
+      body: Center(
+        child: Column(
+          children: [
+            SearchTextField(
+              controller: controller,
+              onChanged: (value) {
+                // TODO: リポジトリ検索実行時の実装
+                setState(() {
+                  _text = value;
+                });
+              },
+              onCancelButtonPressed: () {
+                // TODO: リポジトリ検索キャンセル時の実装
+                setState(() {
+                  _text = '';
+                  controller.clear();
+                });
+                FocusScope.of(context).unfocus();
+              },
+              labelText:
+                  AppLocalizations.of(context)?.searchRepositories ??
+                  WordingData.searchRepositories,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+
+    properties.add(StringProperty('text', _text));
+    properties.add(
+      DiagnosticsProperty<TextEditingController>('controller', controller),
     );
   }
 }

--- a/lib/view/page/search_page.dart
+++ b/lib/view/page/search_page.dart
@@ -42,6 +42,12 @@ class _SearchPageState extends State<SearchPage> {
                     _text = value;
                   });
                 },
+                onSubmitted: (value) {
+                  // TODO: エンターキーや検索ボタンでの検索実行時の実装
+                  setState(() {
+                    _text = value;
+                  });
+                },
                 onCancelButtonPressed: () {
                   // TODO: リポジトリ検索キャンセル時の実装
                   setState(() {

--- a/lib/view/page/search_page.dart
+++ b/lib/view/page/search_page.dart
@@ -19,38 +19,42 @@ class _SearchPageState extends State<SearchPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          AppLocalizations.of(context)?.searchPageTitle ??
-              WordingData.searchPageTitle,
+    return GestureDetector(
+      onTap: () {
+        FocusScope.of(context).unfocus();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            AppLocalizations.of(context)?.searchPageTitle ??
+                WordingData.searchPageTitle,
+          ),
         ),
-      ),
-      drawer: const CustomDrawer(),
-      body: Center(
-        child: Column(
-          children: [
-            SearchTextField(
-              controller: controller,
-              onChanged: (value) {
-                // TODO: リポジトリ検索実行時の実装
-                setState(() {
-                  _text = value;
-                });
-              },
-              onCancelButtonPressed: () {
-                // TODO: リポジトリ検索キャンセル時の実装
-                setState(() {
-                  _text = '';
-                  controller.clear();
-                });
-                FocusScope.of(context).unfocus();
-              },
-              labelText:
-                  AppLocalizations.of(context)?.searchRepositories ??
-                  WordingData.searchRepositories,
-            ),
-          ],
+        drawer: const CustomDrawer(),
+        body: Center(
+          child: Column(
+            children: [
+              SearchTextField(
+                controller: controller,
+                onChanged: (value) {
+                  // TODO: リポジトリ検索実行時の実装
+                  setState(() {
+                    _text = value;
+                  });
+                },
+                onCancelButtonPressed: () {
+                  // TODO: リポジトリ検索キャンセル時の実装
+                  setState(() {
+                    _text = '';
+                    controller.clear();
+                  });
+                },
+                labelText:
+                    AppLocalizations.of(context)?.searchRepositories ??
+                    WordingData.searchRepositories,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/view/widget/search_text_field.dart
+++ b/lib/view/widget/search_text_field.dart
@@ -8,12 +8,14 @@ class SearchTextField extends StatelessWidget {
     this.onChanged,
     this.onCancelButtonPressed,
     this.labelText,
+    this.onSubmitted,
   });
 
   final TextEditingController? controller;
   final void Function(String)? onChanged;
   final void Function()? onCancelButtonPressed;
   final String? labelText;
+  final void Function(String)? onSubmitted;
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +32,7 @@ class SearchTextField extends StatelessWidget {
           labelText: labelText,
         ),
         onChanged: onChanged,
+        onSubmitted: onSubmitted,
       ),
     );
   }
@@ -50,5 +53,11 @@ class SearchTextField extends StatelessWidget {
       ),
     );
     properties.add(StringProperty('labelText', labelText));
+    properties.add(
+      ObjectFlagProperty<void Function(String p1)?>.has(
+        'onSubmitted',
+        onSubmitted,
+      ),
+    );
   }
 }

--- a/lib/view/widget/search_text_field.dart
+++ b/lib/view/widget/search_text_field.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class SearchTextField extends StatelessWidget {
+  const SearchTextField({
+    super.key,
+    this.controller,
+    this.onChanged,
+    this.onCancelButtonPressed,
+    this.labelText,
+  });
+
+  final TextEditingController? controller;
+  final void Function(String)? onChanged;
+  final void Function()? onCancelButtonPressed;
+  final String? labelText;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: TextField(
+        controller: controller ?? TextEditingController(),
+        decoration: InputDecoration(
+          prefixIcon: const Icon(Icons.search),
+          suffixIcon: IconButton(
+            onPressed: onCancelButtonPressed,
+            icon: const Icon(Icons.cancel),
+          ),
+          labelText: labelText,
+        ),
+        onChanged: onChanged,
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      DiagnosticsProperty<TextEditingController?>('controller', controller),
+    );
+    properties.add(
+      ObjectFlagProperty<void Function(String p1)?>.has('onChanged', onChanged),
+    );
+    properties.add(
+      DiagnosticsProperty<void Function()?>(
+        'onCancelButtonPressed',
+        onCancelButtonPressed,
+      ),
+    );
+    properties.add(StringProperty('labelText', labelText));
+  }
+}

--- a/test/unit/view/page/search_page_test.dart
+++ b/test/unit/view/page/search_page_test.dart
@@ -28,5 +28,50 @@ void main() {
       );
       expect(find.text('Search Repository'), findsOneWidget);
     });
+    testWidgets('検索テキストボックスに入力した内容が表示される', (tester) async {
+      await pumpAppWithLocale(
+        tester: tester,
+        locale: const Locale('ja'),
+        home: const SearchPage(),
+      );
+      // テキストボックスに入力
+      const inputText = 'Flutter';
+      await tester.enterText(find.byType(TextField), inputText);
+      await tester.pump();
+      // 入力内容がTextFieldに表示されていること
+      expect(find.text(inputText), findsOneWidget);
+    });
+    testWidgets('キャンセルボタン押下でテキストがクリアされる', (tester) async {
+      await pumpAppWithLocale(
+        tester: tester,
+        locale: const Locale('ja'),
+        home: const SearchPage(),
+      );
+      // テキスト入力
+      const inputText = 'Flutter';
+      await tester.enterText(find.byType(TextField), inputText);
+      await tester.pump();
+      expect(find.text(inputText), findsOneWidget);
+      // キャンセルボタン押下
+      await tester.tap(find.byIcon(Icons.cancel));
+      await tester.pump();
+      // テキストがクリアされていること
+      expect(find.text(inputText), findsNothing);
+    });
+
+    testWidgets('ロケール切り替えでlabelTextが切り替わる', (tester) async {
+      await pumpAppWithLocale(
+        tester: tester,
+        locale: const Locale('en'),
+        home: const SearchPage(),
+      );
+      expect(find.text('Search repositories'), findsOneWidget);
+      await pumpAppWithLocale(
+        tester: tester,
+        locale: const Locale('ja'),
+        home: const SearchPage(),
+      );
+      expect(find.text('リポジトリを検索'), findsOneWidget);
+    });
   });
 }

--- a/test/unit/view/widget/search_text_field_test.dart
+++ b/test/unit/view/widget/search_text_field_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/search_text_field.dart';
+
+void main() {
+  group('SearchTextField', () {
+    testWidgets('labelTextが表示される', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SearchTextField(labelText: '検索'),
+          ),
+        ),
+      );
+      expect(find.text('検索'), findsOneWidget);
+    });
+
+    testWidgets('onChangedが呼ばれる', (tester) async {
+      String? value;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchTextField(
+              onChanged: (v) => value = v,
+            ),
+          ),
+        ),
+      );
+      await tester.enterText(find.byType(TextField), 'abc');
+      expect(value, 'abc');
+    });
+
+    testWidgets('onCancelButtonPressedが呼ばれる', (tester) async {
+      var pressed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchTextField(
+              onCancelButtonPressed: () => pressed = true,
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byIcon(Icons.cancel));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('テキスト入力時にTextFieldに表示される', (tester) async {
+      final controller = TextEditingController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchTextField(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+      await tester.enterText(find.byType(TextField), 'Flutter');
+      // pumpでUI更新を反映
+      await tester.pump();
+      expect(controller.text, 'Flutter');
+      expect(find.text('Flutter'), findsOneWidget);
+    });
+  });
+}

--- a/test/unit/view/widget/search_text_field_test.dart
+++ b/test/unit/view/widget/search_text_field_test.dart
@@ -62,5 +62,21 @@ void main() {
       expect(controller.text, 'Flutter');
       expect(find.text('Flutter'), findsOneWidget);
     });
+
+    testWidgets('onSubmittedが呼ばれる', (tester) async {
+      String? submittedValue;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchTextField(
+              onSubmitted: (v) => submittedValue = v,
+            ),
+          ),
+        ),
+      );
+      await tester.enterText(find.byType(TextField), 'Dart');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      expect(submittedValue, 'Dart');
+    });
   });
 }


### PR DESCRIPTION
## 概要

検索テキストボックスを実装した

## 関連Issue

#35 

## 変更内容

### 検索テキストボックスについて

- テキスト入力欄（TextField）を提供
- 入力内容の変更を検知するコールバック（onChanged）に対応
- 入力確定時のコールバック（onSubmitted）に対応
- ラベルテキスト（labelText）の表示に対応
- クリアボタン（キャンセルボタン）を設置し、押下時のコールバック（onCancelButtonPressed）に対応
- コントローラー（TextEditingController）による外部からの制御に対応
- アイコン（検索・キャンセル）付きの装飾
- テーマに応じたスタイル適用

### 主な変更内容まとめ

- 検索テキストボックスの新規追加
  - lib/view/widget/search_text_field.dart
  - test/unit/view/widget/search_text_field_test.dart

- 検索ページのUI・ロジック追加
  - lib/view/page/search_page.dart
  - test/unit/view/page/search_page_test.dart

- テーマや文言の多言語対応強化
  - lib/l10n/app_en.arb
  - lib/l10n/app_ja.arb
  - lib/l10n/app_localizations.dart
  - lib/l10n/app_localizations_en.dart
  - lib/l10n/app_localizations_ja.dart
  - lib/l10n/strings.csv
  - lib/static/wording_data.dart

- テストコードの追加・拡充
  - test/unit/view/page/search_page_test.dart
  - test/unit/view/widget/search_text_field_test.dart

## 動作確認内容

適当なTextウィジェットを作成し文字列が反映されていることを確認。
各プロパティの有無による表示の変化に問題がないことを確認。

<img height="400" alt="スクリーンショット 2025-06-22 3 02 19" src="https://github.com/user-attachments/assets/d0576e1f-b4be-4761-8d7e-29ba48a6b607" />
<img height="400"  alt="スクリーンショット 2025-06-22 3 03 21" src="https://github.com/user-attachments/assets/28bfa12c-0306-471b-a507-5f3b9243c3ee" />
<img height="400" alt="スクリーンショット 2025-06-22 3 02 12" src="https://github.com/user-attachments/assets/0b452711-d660-4f0f-b27b-3b1a6a07045a" />


## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
