### PR TITLE
デバウンス処理の実装

### DIFF
--- a/lib/domain/model/git_hub_search_api/git_hub_search_api_repository.dart
+++ b/lib/domain/model/git_hub_search_api/git_hub_search_api_repository.dart
@@ -6,9 +6,9 @@ import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_ap
 
 part 'git_hub_search_api_repository.g.dart';
 
-@riverpod
-GitHubSearchApiRepository apiRepository(Ref ref) {
-  return GitHubSearchApiRepository(dio: Dio());
+@Riverpod(keepAlive: true)
+GitHubSearchApiRepository apiRepository(Ref ref, Dio dio) {
+  return GitHubSearchApiRepository(dio: dio);
 }
 
 class GitHubSearchApiRepository {

--- a/lib/domain/model/git_hub_search_api/git_hub_search_api_repository.g.dart
+++ b/lib/domain/model/git_hub_search_api/git_hub_search_api_repository.g.dart
@@ -6,24 +6,147 @@ part of 'git_hub_search_api_repository.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$apiRepositoryHash() => r'046ace329af3aa64b52d7cd5916b207483de16fc';
+String _$apiRepositoryHash() => r'79ae13e48524261b7362ae5a6a2ab82855d66d97';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
 
 /// See also [apiRepository].
 @ProviderFor(apiRepository)
-final apiRepositoryProvider =
-    AutoDisposeProvider<GitHubSearchApiRepository>.internal(
-      apiRepository,
-      name: r'apiRepositoryProvider',
-      debugGetCreateSourceHash:
-          const bool.fromEnvironment('dart.vm.product')
-              ? null
-              : _$apiRepositoryHash,
-      dependencies: null,
-      allTransitiveDependencies: null,
+const apiRepositoryProvider = ApiRepositoryFamily();
+
+/// See also [apiRepository].
+class ApiRepositoryFamily extends Family<GitHubSearchApiRepository> {
+  /// See also [apiRepository].
+  const ApiRepositoryFamily();
+
+  /// See also [apiRepository].
+  ApiRepositoryProvider call(Dio dio) {
+    return ApiRepositoryProvider(dio);
+  }
+
+  @override
+  ApiRepositoryProvider getProviderOverride(
+    covariant ApiRepositoryProvider provider,
+  ) {
+    return call(provider.dio);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'apiRepositoryProvider';
+}
+
+/// See also [apiRepository].
+class ApiRepositoryProvider extends Provider<GitHubSearchApiRepository> {
+  /// See also [apiRepository].
+  ApiRepositoryProvider(Dio dio)
+    : this._internal(
+        (ref) => apiRepository(ref as ApiRepositoryRef, dio),
+        from: apiRepositoryProvider,
+        name: r'apiRepositoryProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$apiRepositoryHash,
+        dependencies: ApiRepositoryFamily._dependencies,
+        allTransitiveDependencies:
+            ApiRepositoryFamily._allTransitiveDependencies,
+        dio: dio,
+      );
+
+  ApiRepositoryProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.dio,
+  }) : super.internal();
+
+  final Dio dio;
+
+  @override
+  Override overrideWith(
+    GitHubSearchApiRepository Function(ApiRepositoryRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: ApiRepositoryProvider._internal(
+        (ref) => create(ref as ApiRepositoryRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        dio: dio,
+      ),
     );
+  }
+
+  @override
+  ProviderElement<GitHubSearchApiRepository> createElement() {
+    return _ApiRepositoryProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ApiRepositoryProvider && other.dio == dio;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, dio.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef ApiRepositoryRef = AutoDisposeProviderRef<GitHubSearchApiRepository>;
+mixin ApiRepositoryRef on ProviderRef<GitHubSearchApiRepository> {
+  /// The parameter `dio` of this provider.
+  Dio get dio;
+}
+
+class _ApiRepositoryProviderElement
+    extends ProviderElement<GitHubSearchApiRepository>
+    with ApiRepositoryRef {
+  _ApiRepositoryProviderElement(super.provider);
+
+  @override
+  Dio get dio => (origin as ApiRepositoryProvider).dio;
+}
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/domain/model/git_hub_search_api/git_hub_search_query.dart
+++ b/lib/domain/model/git_hub_search_api/git_hub_search_query.dart
@@ -43,7 +43,7 @@ extension GitHubSearchOrderExtension on GitHubSearchOrder {
   String get value => toString().split('.').last;
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 class GitHubSearchQueryNotifier extends _$GitHubSearchQueryNotifier {
   @override
   GitHubSearchQuery build() {

--- a/lib/domain/model/git_hub_search_api/git_hub_search_query.g.dart
+++ b/lib/domain/model/git_hub_search_api/git_hub_search_query.g.dart
@@ -7,24 +7,22 @@ part of 'git_hub_search_query.dart';
 // **************************************************************************
 
 String _$gitHubSearchQueryNotifierHash() =>
-    r'6a00311445c6b3e1d8c773cf0b83db0014577a14';
+    r'745bb2a26f8d0a5ab6a491b1922a482ecae2e5c2';
 
 /// See also [GitHubSearchQueryNotifier].
 @ProviderFor(GitHubSearchQueryNotifier)
-final gitHubSearchQueryNotifierProvider = AutoDisposeNotifierProvider<
-  GitHubSearchQueryNotifier,
-  GitHubSearchQuery
->.internal(
-  GitHubSearchQueryNotifier.new,
-  name: r'gitHubSearchQueryNotifierProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product')
-          ? null
-          : _$gitHubSearchQueryNotifierHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+final gitHubSearchQueryNotifierProvider =
+    NotifierProvider<GitHubSearchQueryNotifier, GitHubSearchQuery>.internal(
+      GitHubSearchQueryNotifier.new,
+      name: r'gitHubSearchQueryNotifierProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$gitHubSearchQueryNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
 
-typedef _$GitHubSearchQueryNotifier = AutoDisposeNotifier<GitHubSearchQuery>;
+typedef _$GitHubSearchQueryNotifier = Notifier<GitHubSearchQuery>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/domain/model/git_hub_search_api/repository.dart
+++ b/lib/domain/model/git_hub_search_api/repository.dart
@@ -6,14 +6,19 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/git_hub_search_api_repository.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/git_hub_search_query.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
+import 'package:yumemi_flutter_engineer_codecheck/extension/debounce_and_cancel_extension.dart';
 
 part 'repository.freezed.dart';
 part 'repository.g.dart';
 
 @riverpod
-Future<List<Repository>> repositiesSearchResult(Ref ref) {
-  final repository = ref.watch(apiRepositoryProvider);
+Future<List<Repository>> repositiesSearchResult(Ref ref) async {
   final query = ref.watch(gitHubSearchQueryNotifierProvider);
+  if (query.q.isEmpty) {
+    return [];
+  }
+  final dio = await ref.getDebouncedHttpClient();
+  final repository = ref.watch(apiRepositoryProvider(dio));
   return repository.fetch(query);
 }
 

--- a/lib/domain/model/git_hub_search_api/repository.g.dart
+++ b/lib/domain/model/git_hub_search_api/repository.g.dart
@@ -35,7 +35,7 @@ Map<String, dynamic> _$RepositoryToJson(_Repository instance) =>
 // **************************************************************************
 
 String _$repositiesSearchResultHash() =>
-    r'7d4e63e680f7b7696bba23b0c2b30a63a97e70c7';
+    r'29797e8b5ac305dce75aeb14fbd987012fc916ae';
 
 /// See also [repositiesSearchResult].
 @ProviderFor(repositiesSearchResult)

--- a/lib/extension/debounce_and_cancel_extension.dart
+++ b/lib/extension/debounce_and_cancel_extension.dart
@@ -3,25 +3,33 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+/// テストや共通設定のためにDioやTimerの注入を可能にした拡張
 extension DebounceAndCancelExtension on Ref {
   /// デバウンス・キャンセル処理を実装した [Dio] を返します。
   ///
-  /// - デバウンス処理とは、ユーザーが入力をやめてから一定時間後にリクエストを送信することです。
-  ///   例えば、ユーザーがテキストボックスに入力している最中にリクエストを送信しないようにするために使用されます。
-  ///   この処理により、ユーザーが入力を完了してから500ms経ったあとにリクエストが送信されます。
-  ///   デフォルトの待機時間は500msです。一般的には 500ms 程度で十分とされていますが、必要に応じて変更可能です。
+  /// [dio] でDioインスタンスを注入できます。未指定時は新規生成。
+  /// [timerFactory] でTimerの生成方法を注入できます（テスト用）。
   ///
-  /// - キャンセル処理とは、ユーザーがリクエスト中に値の監視をやめた場合にリクエストをキャンセルすることです。
-  ///   例えば、ユーザーがテキストボックスに入力中にダイアログごと閉じた時などに発動します。
-  ///   この処理により、ユーザーがリクエスト中に値の監視をやめた場合、リクエストはキャンセルされます。
-  /// 
+  /// - デバウンス処理とは、ユーザーが入力をやめてから一定時間後にリクエストを送信することです。<BR>
+  ///   例えば、ユーザーがテキストボックスに入力している最中にリクエストを送信しないようにするために使用されます。<BR>
+  ///   この処理により、ユーザーが入力を完了してから500ms経ったあとにリクエストが送信されます。<BR>
+  ///   デフォルトの待機時間は500msです。一般的には 500ms 程度で十分とされていますが、必要に応じて変更可能です。<BR>
+  ///
+  /// - キャンセル処理とは、ユーザーがリクエスト中に値の監視をやめた場合にリクエストをキャンセルすることです。<BR>
+  ///   例えば、ユーザーがテキストボックスに入力中にダイアログごと閉じた時などに発動します。<BR>
+  ///   この処理により、ユーザーがリクエスト中に値の監視をやめた場合、リクエストはキャンセルされます。<BR>
+  ///
   /// 参考 : https://riverpod.dev/docs/case_studies/cancel#going-further-doing-both-at-once
-  Future<Dio> getDebouncedHttpClient([Duration? duration]) async {
+  Future<Dio> getDebouncedHttpClient({
+    Duration? duration,
+    Dio? dio,
+    Timer Function(Duration duration, void Function() callback)? timerFactory,
+  }) async {
     var didDispose = false;
     onDispose(() => didDispose = true);
 
     final completer = Completer<void>();
-    final timer = Timer(
+    final timer = (timerFactory ?? Timer.new)(
       duration ?? const Duration(milliseconds: 500),
       completer.complete,
     );
@@ -38,9 +46,9 @@ extension DebounceAndCancelExtension on Ref {
       throw Exception('Cancelled');
     }
 
-    final dio = Dio();
-    onDispose(dio.close);
+    final client = dio ?? Dio();
+    onDispose(client.close);
 
-    return dio;
+    return client;
   }
 }

--- a/lib/extension/debounce_and_cancel_extension.dart
+++ b/lib/extension/debounce_and_cancel_extension.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension DebounceAndCancelExtension on Ref {
+  /// デバウンス・キャンセル処理を実装した [Dio] を返します。
+  ///
+  /// - デバウンス処理とは、ユーザーが入力をやめてから一定時間後にリクエストを送信することです。
+  ///   例えば、ユーザーがテキストボックスに入力している最中にリクエストを送信しないようにするために使用されます。
+  ///   この処理により、ユーザーが入力を完了してから500ms経ったあとにリクエストが送信されます。
+  ///   デフォルトの待機時間は500msです。一般的には 500ms 程度で十分とされていますが、必要に応じて変更可能です。
+  ///
+  /// - キャンセル処理とは、ユーザーがリクエスト中に値の監視をやめた場合にリクエストをキャンセルすることです。
+  ///   例えば、ユーザーがテキストボックスに入力中にダイアログごと閉じた時などに発動します。
+  ///   この処理により、ユーザーがリクエスト中に値の監視をやめた場合、リクエストはキャンセルされます。
+  /// 
+  /// 参考 : https://riverpod.dev/docs/case_studies/cancel#going-further-doing-both-at-once
+  Future<Dio> getDebouncedHttpClient([Duration? duration]) async {
+    var didDispose = false;
+    onDispose(() => didDispose = true);
+
+    final completer = Completer<void>();
+    final timer = Timer(
+      duration ?? const Duration(milliseconds: 500),
+      completer.complete,
+    );
+    onDispose(() {
+      timer.cancel();
+      if (!completer.isCompleted) {
+        completer.completeError(Exception('Cancelled'));
+      }
+    });
+
+    await completer.future;
+
+    if (didDispose) {
+      throw Exception('Cancelled');
+    }
+
+    final dio = Dio();
+    onDispose(dio.close);
+
+    return dio;
+  }
+}

--- a/lib/view/page/search_page.dart
+++ b/lib/view/page/search_page.dart
@@ -16,8 +16,6 @@ class SearchPage extends ConsumerStatefulWidget {
 }
 
 class _SearchPageState extends ConsumerState<SearchPage> {
-  var _text = '';
-
   final controller = TextEditingController();
 
   @override
@@ -39,30 +37,18 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             children: [
               SearchTextField(
                 controller: controller,
-                // TODO :
-                // 　onChanged を使用すると、入力中にAPIを叩いてしまうため、現状は onSubmitted のみを使用する。
-                // 　例えば、Debounceを使用して、一定時間入力がない場合にAPIを叩くようにするなどして改善後にコメント解除する。
-                // onChanged: (value) {
-                //   setState(() {
-                //     _text = value;
-                //   });
-                //   ref
-                //       .read(gitHubSearchQueryNotifierProvider.notifier)
-                //       .setQuery(q: _text);
-                // },
-                onSubmitted: (value) {
-                  setState(() {
-                    _text = value;
-                  });
+                onChanged: (value) {
                   ref
                       .read(gitHubSearchQueryNotifierProvider.notifier)
-                      .setQuery(q: _text);
+                      .setQuery(q: value);
+                },
+                onSubmitted: (value) {
+                  ref
+                      .read(gitHubSearchQueryNotifierProvider.notifier)
+                      .setQuery(q: value);
                 },
                 onCancelButtonPressed: () {
-                  setState(() {
-                    _text = '';
-                    controller.clear();
-                  });
+                  setState(controller.clear);
                   ref
                       .read(gitHubSearchQueryNotifierProvider.notifier)
                       .setQuery(q: '');
@@ -86,7 +72,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
 
-    properties.add(StringProperty('text', _text));
     properties.add(
       DiagnosticsProperty<TextEditingController>('controller', controller),
     );

--- a/test/extension/debounce_and_cancel_extension_test.dart
+++ b/test/extension/debounce_and_cancel_extension_test.dart
@@ -1,0 +1,139 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/extension/debounce_and_cancel_extension.dart';
+
+/// デバウンス処理とキャンセル処理を実装したDioのFutureProvider
+///
+/// - [params] には以下のキーを含むMapを渡す必要があります:
+///   - `duration`: デバウンスの遅延時間（Duration型）
+///   - `dio`: オプションでDioインスタンスを指定できます（Dio型）
+///   - `timerFactory`: オプションでTimerの生成方法を指定できます
+///     （`Timer Function(Duration duration, void Function() callback)`型）
+final FutureProviderFamily<Dio, Map<String, dynamic>> _debouncedDioProvider =
+    FutureProvider.family<Dio, Map<String, dynamic>>((ref, params) {
+      return ref.getDebouncedHttpClient(
+        duration: params['duration'] as Duration?,
+        dio: params['dio'] as Dio?,
+        timerFactory:
+            params['timerFactory']
+                as Timer Function(Duration, void Function())?,
+      );
+    });
+
+void main() {
+  group('HTTPリクエストのデバウンス処理とキャンセル処理を実装したRef拡張のテスト', () {
+    test('デバウンス後にDioが返る', () async {
+      final container = ProviderContainer();
+      var timerCalled = false;
+      final dio = Dio();
+      Timer timerFactory(Duration duration, void Function() callback) {
+        timerCalled = true;
+        return Timer(duration, callback);
+      }
+
+      final params = {
+        'duration': const Duration(milliseconds: 10),
+        'dio': dio,
+        'timerFactory': timerFactory,
+      };
+      // Futureを取得してからdisposeする
+      // これにより、デバウンス後にDioが返ることを確認する
+      // また、timerFactoryが呼ばれたことも確認する
+      final result = await container.read(_debouncedDioProvider(params).future);
+      expect(result, equals(dio));
+      expect(timerCalled, isTrue);
+      // awaitの後にdisposeすることで、disposeによるキャンセル例外を回避
+      container.dispose();
+    });
+
+    test('キャンセル時に例外が投げられる', () {
+      final container = ProviderContainer();
+      Timer timerFactory(Duration duration, void Function() callback) {
+        return Timer(duration, callback);
+      }
+
+      final params = {
+        'duration': const Duration(seconds: 1),
+        'timerFactory': timerFactory,
+      };
+      // Futureを取得してからdisposeする
+      // これにより、キャンセル時に例外が投げられることを確認する
+      final future = container.read(_debouncedDioProvider(params).future);
+      container.dispose();
+      expect(future, throwsException);
+    });
+
+    test('デバウンス中にdisposeするとTimerがキャンセルされる', () {
+      final container = ProviderContainer();
+      var timerCancelled = false;
+      _TestTimer timerFactory(Duration duration, void Function() callback) {
+        return _TestTimer(
+          duration,
+          callback,
+          onCancel: () {
+            timerCancelled = true;
+          },
+        );
+      }
+
+      final params = {
+        'duration': const Duration(seconds: 1),
+        'timerFactory': timerFactory,
+      };
+      // Futureを取得してからdisposeする
+      // これにより、タイマーがキャンセルされることを確認する
+      final future = container.read(_debouncedDioProvider(params).future);
+      container.dispose();
+      expect(timerCancelled, isTrue);
+      expect(future, throwsException);
+    });
+  });
+}
+
+/// テスト用のTimer実装
+///
+/// 実際のTimerではなく、Future.delayedを使用して非同期処理を模倣します。
+class _TestTimer implements Timer {
+  /// コンストラクタ
+  ///
+  /// - duration : タイマーの遅延時間
+  /// - callback : タイマーが完了したときに呼び出されるコールバック関数
+  /// - onCancel : タイマーがキャンセルされたときに呼び出されるコールバック関数
+  ///
+  /// デフォルトでは何もしません。
+  _TestTimer(
+    Duration duration,
+    void Function() callback, {
+    void Function()? onCancel,
+  }) : _onCancel = onCancel ?? (() {}) {
+    Future.delayed(duration, () {
+      if (_isActive) {
+        callback();
+      }
+    });
+  }
+
+  /// キャンセル時に呼ばれるコールバック
+  final void Function() _onCancel;
+
+  /// キャンセル状態を管理するフラグ
+  var _isActive = true;
+
+  /// Timerのキャンセル処理
+  @override
+  void cancel() {
+    _isActive = false;
+    _onCancel();
+  }
+
+  /// Timerの状態を確認するためのフラグ
+  @override
+  bool get isActive => _isActive;
+
+  /// Timerの残り時間を取得するためのメソッド
+  @override
+  int get tick => 0;
+}

--- a/test/extension/debounce_and_cancel_extension_test.dart
+++ b/test/extension/debounce_and_cancel_extension_test.dart
@@ -7,7 +7,7 @@ import 'package:yumemi_flutter_engineer_codecheck/extension/debounce_and_cancel_
 
 /// デバウンス処理とキャンセル処理を実装したDioのFutureProvider
 ///
-/// - [params] には以下のキーを含むMapを渡す必要があります:
+/// - params には以下のキーを含むMapを渡す必要があります:
 ///   - `duration`: デバウンスの遅延時間（Duration型）
 ///   - `dio`: オプションでDioインスタンスを指定できます（Dio型）
 ///   - `timerFactory`: オプションでTimerの生成方法を指定できます

--- a/test/unit/view/page/search_page_test.dart
+++ b/test/unit/view/page/search_page_test.dart
@@ -40,6 +40,8 @@ void main() {
       await tester.pump();
       // 入力内容がTextFieldに表示されていること
       expect(find.text(inputText), findsOneWidget);
+      // タイマーなどの保留中処理を解消
+      await tester.pumpAndSettle();
     });
     testWidgets('キャンセルボタン押下でテキストがクリアされる', (tester) async {
       await pumpAppWithLocale(
@@ -57,6 +59,8 @@ void main() {
       await tester.pump();
       // テキストがクリアされていること
       expect(find.text(inputText), findsNothing);
+      // タイマーなどの保留中処理を解消
+      await tester.pumpAndSettle();
     });
 
     testWidgets('ロケール切り替えでlabelTextが切り替わる', (tester) async {


### PR DESCRIPTION
## 概要

GitHub search repositories API を叩く際のデバウンス処理(＋αでキャンセル処理)を実装した。

これにより無駄なリクエストが発生してしまいパフォーマンスやコストを無駄に消費してしまうことを軽減した

## 関連Issue

#51 

## 変更内容

### 主な内容

- GitHubリポジトリ検索APIの実装・リファクタ
  - /lib/domain/model/git_hub_search_api/git_hub_search_api_repository.dart
  - /lib/domain/model/git_hub_search_api/git_hub_search_api_repository.g.dart
  - /lib/domain/model/git_hub_search_api/git_hub_search_query.dart
  - /lib/domain/model/git_hub_search_api/git_hub_search_query.g.dart
  - /lib/domain/model/git_hub_search_api/repository.dart
  - /lib/domain/model/git_hub_search_api/repository.g.dart

- debounce/cancel拡張の追加・テスト
  - /lib/extension/debounce_and_cancel_extension.dart
  - /test/extension/debounce_and_cancel_extension_test.dart

- 検索ページのUI・ロジック追加・修正
  - /lib/view/page/search_page.dart
  - /test/unit/view/page/search_page_test.dart

### 詳細

- GitHubリポジトリ検索APIのリポジトリ層・クエリ層・モデル層の新規作成・リファクタ
- Riverpod/Freezed/JsonSerializableによるProviderやモデルの自動生成コード追加
- debounce/cancel機能付きDioクライアントのRef拡張を追加し、テストも実装
- 検索ページでのテキスト入力・キャンセル・ローカライズ対応のUI/ロジック追加
- 検索ページのWidgetテストを日本語・英語・キャンセルボタン・ラベル切り替え等で拡充

## 動作確認内容

- print文を至る所に仕込み意図した動作になっていることを確認した。
- 自動テストが全て通ること

![デバウンス処理](https://github.com/user-attachments/assets/dacacecb-b707-44f3-940a-0b6ecacd38da)

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
