### PR TITLE
リポジトリの詳細情報を表示するページの実装

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -30,5 +30,29 @@
   "searchRepositories": "Search repositories",
   "@searchRepositories": {
     "description": "The label for searching repositories."
+  },
+  "repoLanguage": "Language",
+  "@repoLanguage": {
+    "description": "The programming language of the repository."
+  },
+  "repoStars": "Stars",
+  "@repoStars": {
+    "description": "The number of stars of the repository."
+  },
+  "repoWatchers": "Watchers",
+  "@repoWatchers": {
+    "description": "The number of watchers of the repository."
+  },
+  "repoForks": "Forks",
+  "@repoForks": {
+    "description": "The number of forks of the repository."
+  },
+  "repoIssues": "Issues",
+  "@repoIssues": {
+    "description": "The number of open issues of the repository."
+  },
+  "repoDetailsInfo": "Repository Details Info",
+  "@repoDetailsInfo": {
+    "description": "The title for the repository details page."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -6,5 +6,11 @@
   "themeModeLight": "ライト",
   "themeModeDark": "ダーク",
   "themeModeSelect": "テーマモードを選択",
-  "searchRepositories": "リポジトリを検索"
+  "searchRepositories": "リポジトリを検索",
+  "repoLanguage": "言語",
+  "repoStars": "スター",
+  "repoWatchers": "ウォッチ",
+  "repoForks": "フォーク",
+  "repoIssues": "イシュー",
+  "repoDetailsInfo": "リポジトリ詳細"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -145,6 +145,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Search repositories'**
   String get searchRepositories;
+
+  /// The programming language of the repository.
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get repoLanguage;
+
+  /// The number of stars of the repository.
+  ///
+  /// In en, this message translates to:
+  /// **'Stars'**
+  String get repoStars;
+
+  /// The number of watchers of the repository.
+  ///
+  /// In en, this message translates to:
+  /// **'Watchers'**
+  String get repoWatchers;
+
+  /// The number of forks of the repository.
+  ///
+  /// In en, this message translates to:
+  /// **'Forks'**
+  String get repoForks;
+
+  /// The number of open issues of the repository.
+  ///
+  /// In en, this message translates to:
+  /// **'Issues'**
+  String get repoIssues;
+
+  /// The title for the repository details page.
+  ///
+  /// In en, this message translates to:
+  /// **'Repository Details Info'**
+  String get repoDetailsInfo;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -31,4 +31,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchRepositories => 'Search repositories';
+
+  @override
+  String get repoLanguage => 'Language';
+
+  @override
+  String get repoStars => 'Stars';
+
+  @override
+  String get repoWatchers => 'Watchers';
+
+  @override
+  String get repoForks => 'Forks';
+
+  @override
+  String get repoIssues => 'Issues';
+
+  @override
+  String get repoDetailsInfo => 'Repository Details Info';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -31,4 +31,22 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get searchRepositories => 'リポジトリを検索';
+
+  @override
+  String get repoLanguage => '言語';
+
+  @override
+  String get repoStars => 'スター';
+
+  @override
+  String get repoWatchers => 'ウォッチ';
+
+  @override
+  String get repoForks => 'フォーク';
+
+  @override
+  String get repoIssues => 'イシュー';
+
+  @override
+  String get repoDetailsInfo => 'リポジトリ詳細';
 }

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -7,3 +7,9 @@ themeModeLight,The label for light theme mode.,Light,ライト
 themeModeDark,The label for dark theme mode.,Dark,ダーク
 themeModeSelect,The label for selecting theme mode.,Select Theme Mode,テーマモードを選択
 searchRepositories,The label for searching repositories.,Search repositories,リポジトリを検索
+repoLanguage,The programming language of the repository.,Language,言語
+repoStars,The number of stars of the repository.,Stars,スター
+repoWatchers,The number of watchers of the repository.,Watchers,ウォッチ
+repoForks,The number of forks of the repository.,Forks,フォーク
+repoIssues,The number of open issues of the repository.,Issues,イシュー
+repoDetailsInfo,The title for the repository details page.,Repository Details Info,リポジトリ詳細

--- a/lib/provider/go_router_provider.dart
+++ b/lib/provider/go_router_provider.dart
@@ -24,9 +24,19 @@ GoRouter createGoRouter() {
           GoRoute(
             path: AppRoutes.details,
             name: 'details',
-            builder: (context, state) {
+            pageBuilder: (context, state) {
               final repository = state.extra! as Repository;
-              return RepositoryDetailsPage(repository: repository);
+              return CustomTransitionPage<RepositoryDetailsPage>(
+                child: RepositoryDetailsPage(repository: repository),
+                transitionsBuilder: (
+                  context,
+                  animation,
+                  secondaryAnimation,
+                  child,
+                ) {
+                  return child;
+                },
+              );
             },
           ),
         ],

--- a/lib/provider/go_router_provider.dart
+++ b/lib/provider/go_router_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
@@ -26,7 +27,9 @@ GoRouter createGoRouter() {
             name: 'details',
             pageBuilder: (context, state) {
               final repository = state.extra! as Repository;
-              return CustomTransitionPage<RepositoryDetailsPage>(
+              return CustomTransitionPage(
+                transitionDuration: const Duration(milliseconds: 500),
+                reverseTransitionDuration: const Duration(milliseconds: 500),
                 child: RepositoryDetailsPage(repository: repository),
                 transitionsBuilder: (
                   context,
@@ -34,7 +37,10 @@ GoRouter createGoRouter() {
                   secondaryAnimation,
                   child,
                 ) {
-                  return child;
+                  return FadeTransition(
+                    opacity: animation,
+                    child: child,
+                  );
                 },
               );
             },

--- a/lib/provider/go_router_provider.dart
+++ b/lib/provider/go_router_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:yumemi_flutter_engineer_codecheck/view/page/search_page.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/repositori_search_page.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/repository_details_page.dart';
 
 final goRouterProvider = Provider<GoRouter>(
   (ref) => createGoRouter(),
@@ -8,6 +10,7 @@ final goRouterProvider = Provider<GoRouter>(
 
 class AppRoutes {
   static const root = '/';
+  static const details = 'details';
 }
 
 GoRouter createGoRouter() {
@@ -16,7 +19,17 @@ GoRouter createGoRouter() {
       GoRoute(
         path: AppRoutes.root,
         name: 'home',
-        builder: (context, state) => const SearchPage(),
+        builder: (context, state) => const RepositorySearchPage(),
+        routes: [
+          GoRoute(
+            path: AppRoutes.details,
+            name: 'details',
+            builder: (context, state) {
+              final repository = state.extra! as Repository;
+              return RepositoryDetailsPage(repository: repository);
+            },
+          ),
+        ],
       ),
     ],
   );

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -16,4 +16,18 @@ class WordingData {
   static const themeModeSelect = 'Select Theme Mode';
 
   static const searchRepositories = 'Search repositories';
+
+  static const repoLanguage = 'Language';
+
+  static const repoStars = 'Stars';
+
+  static const repoWatchers = 'Watchers';
+
+  static const repoForks = 'Forks';
+
+  static const repoIssues = 'Issues';
+
+  static const unknownLanguage = 'N/A';
+
+  static const repoDetailsInfo = 'Repository Details Info';
 }

--- a/lib/view/page/repositori_search_page.dart
+++ b/lib/view/page/repositori_search_page.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/git_hub_search_query.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/custom_drawer.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/search_result_list_view.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/search_text_field.dart';
+
+class RepositorySearchPage extends ConsumerStatefulWidget {
+  const RepositorySearchPage({super.key});
+
+  @override
+  ConsumerState<RepositorySearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends ConsumerState<RepositorySearchPage> {
+  final controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        FocusScope.of(context).unfocus();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            AppLocalizations.of(context)?.searchPageTitle ??
+                WordingData.searchPageTitle,
+          ),
+        ),
+        drawer: const CustomDrawer(),
+        body: Center(
+          child: Column(
+            children: [
+              SearchTextField(
+                controller: controller,
+                onChanged: (value) {
+                  ref
+                      .read(gitHubSearchQueryNotifierProvider.notifier)
+                      .setQuery(q: value);
+                },
+                onSubmitted: (value) {
+                  ref
+                      .read(gitHubSearchQueryNotifierProvider.notifier)
+                      .setQuery(q: value);
+                },
+                onCancelButtonPressed: () {
+                  setState(controller.clear);
+                  ref
+                      .read(gitHubSearchQueryNotifierProvider.notifier)
+                      .setQuery(q: '');
+                },
+                labelText:
+                    AppLocalizations.of(context)?.searchRepositories ??
+                    WordingData.searchRepositories,
+              ),
+              const SizedBox(height: 8),
+              const Expanded(
+                child: SearchResultListView(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+
+    properties.add(
+      DiagnosticsProperty<TextEditingController>('controller', controller),
+    );
+  }
+}

--- a/lib/view/page/repository_details_page.dart
+++ b/lib/view/page/repository_details_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_card.dart';
+
+/// リポジトリの詳細情報を表示するページウィジェット
+class RepositoryDetailsPage extends StatelessWidget {
+  const RepositoryDetailsPage({required this.repository, super.key});
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text(
+          AppLocalizations.of(context)?.repoDetailsInfo ??
+              WordingData.repoDetailsInfo,
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            GoRouter.of(context).pop();
+          },
+        ),
+      ),
+      body: Center(
+        child: RepositoryDetailsCard(repository: repository),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}

--- a/lib/view/widget/repository_details_card.dart
+++ b/lib/view/widget/repository_details_card.dart
@@ -1,0 +1,424 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+
+/// GitHubリポジトリ詳細表示ウィジェット
+///
+/// リポジトリの情報をカード形式で表示
+/// レイアウトは画面幅に応じて縦横切り替え
+class RepositoryDetailsCard extends StatelessWidget {
+  const RepositoryDetailsCard({required this.repository, super.key});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Hero(
+        // ヒーローアニメーションを使用してリポジトリの詳細を表示
+        // 検索画面のリストビューと同一のタグを使用することで実現している
+        transitionOnUserGestures: true,
+        tag: 'repository-${repository.name}',
+        child: SizedBox.expand(
+          child: Card(
+            margin: const EdgeInsets.all(8),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+              child: SingleChildScrollView(
+                child: _RepositoryInfo(repository: repository),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリ情報を表示するウィジェット
+///
+/// 画面幅に応じて縦横のレイアウトを切り替える
+/// - 横レイアウト: タイトルとオーナーアイコンを横並び
+/// - 縦レイアウト: タイトルの下にオーナーアイコン
+class _RepositoryInfo extends StatelessWidget {
+  const _RepositoryInfo({required this.repository});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= 600) {
+          return _RepositoryInfoHorizontalLayout(repository: repository);
+        } else {
+          return _RepositoryInfoVerticalLayout(repository: repository);
+        }
+      },
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリ情報の縦方向に長いレイアウト用のウィジェット
+class _RepositoryInfoVerticalLayout extends StatelessWidget {
+  const _RepositoryInfoVerticalLayout({
+    required this.repository,
+  });
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _OwnerIcon(repository: repository),
+        const SizedBox(height: 12),
+        _RepositoryTitle(repository: repository),
+        const SizedBox(height: 16),
+        _RepositoryDetailsInfoView(repository: repository),
+      ],
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリ情報の横方向に長いレイアウト用のウィジェット
+class _RepositoryInfoHorizontalLayout extends StatelessWidget {
+  const _RepositoryInfoHorizontalLayout({
+    required this.repository,
+  });
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _RepositoryTitle(repository: repository),
+        const SizedBox(height: 16),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _OwnerIcon(repository: repository),
+            const SizedBox(width: 24),
+            Expanded(
+              child: _RepositoryDetailsInfoView(repository: repository),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリのオーナーのアバター画像を表示するウィジェット
+///
+/// オーナーが設定されていない場合や画像の読み込みに失敗した場合はデフォルトのアイコンを表示
+/// 読み込み中はCircularProgressIndicatorを表示
+class _OwnerIcon extends StatelessWidget {
+  const _OwnerIcon({required this.repository});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = repository.owner?.avatarUrl;
+
+    if (avatarUrl == null || avatarUrl.isEmpty) {
+      return _buildDefaultAvatar(context);
+    }
+
+    return _DecoratedAvatarCircle(
+      child: ClipOval(
+        child: Image.network(
+          avatarUrl,
+          width: 80,
+          height: 80,
+          fit: BoxFit.cover,
+          errorBuilder: _buildDefaultAvatar,
+          loadingBuilder: _buildImageLoadingIndicator,
+        ),
+      ),
+    );
+  }
+
+  /// デフォルトのアバターを構築する
+  ///
+  /// Ownerがセットされてなかったりエラー時に表示されるウィジェット
+  Widget _buildDefaultAvatar(
+    BuildContext context, [
+    Object? error,
+    StackTrace? stackTrace,
+  ]) {
+    return _DecoratedAvatarCircle(
+      child: Icon(
+        Icons.person,
+        size: 40,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+
+  /// ネットワーク画像のローディング表示を構築する
+  ///
+  /// 読み込み中はCircularProgressIndicatorを表示し、完了時は子ウィジェットをそのまま表示
+  Widget _buildImageLoadingIndicator(
+    BuildContext context,
+    Widget child,
+    ImageChunkEvent? loadingProgress,
+  ) {
+    // 読み込み完了時は子ウィジェットをそのまま表示
+    if (loadingProgress == null) {
+      return child;
+    }
+
+    // 読み込み進捗を計算
+    final progress = _calculateLoadingProgress(loadingProgress);
+
+    return _DecoratedAvatarCircle(
+      child: CircularProgressIndicator(
+        value: progress,
+        strokeWidth: 2,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        valueColor: AlwaysStoppedAnimation<Color>(
+          Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  /// 読み込み進捗を計算する（0.0〜1.0の範囲）
+  double? _calculateLoadingProgress(ImageChunkEvent loadingProgress) {
+    final expectedTotalBytes = loadingProgress.expectedTotalBytes;
+    if (expectedTotalBytes == null) {
+      return null; // 不定進捗
+    }
+
+    return loadingProgress.cumulativeBytesLoaded / expectedTotalBytes;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// 飾りが施されたCircleAvatarウィジェット
+///
+/// 影と背景色を持つ円形のアバターを表示
+class _DecoratedAvatarCircle extends StatelessWidget {
+  const _DecoratedAvatarCircle({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(
+              context,
+            ).colorScheme.shadow.withAlpha((255 * 0.3).round()),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: CircleAvatar(
+        radius: 40,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: child,
+      ),
+    );
+  }
+}
+
+/// リポジトリの詳細情報を表示するウィジェット
+///
+/// リポジトリの言語、スター数、ウォッチャー数、フォーク数、オープンイシュー数を表示
+/// 情報はアイコンとラベル付きでカード形式で表示される
+class _RepositoryDetailsInfoView extends StatelessWidget {
+  const _RepositoryDetailsInfoView({required this.repository});
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      runSpacing: 8,
+      children:
+          _buildInfoItems(
+            context,
+            AppLocalizations.of(context),
+          ).map((item) => _InfoRow(item: item)).toList(),
+    );
+  }
+
+  /// リポジトリ情報項目のリストを構築
+  ///
+  /// 各項目はアイコン、ラベル、値を持つ
+  /// プロジェクト言語、スター数、ウォッチャー数、フォーク数、オープンイシュー数の順で表示
+  List<_InfoRowItem> _buildInfoItems(
+    BuildContext context,
+    AppLocalizations? l10n,
+  ) {
+    return [
+      _InfoRowItem(
+        icon: Icons.code,
+        label: l10n?.repoLanguage ?? WordingData.repoLanguage,
+        value: repository.language ?? WordingData.unknownLanguage,
+      ),
+      _InfoRowItem(
+        icon: Icons.star,
+        label: l10n?.repoStars ?? WordingData.repoStars,
+        value: _formatNumber(context, repository.stargazersCount),
+      ),
+      _InfoRowItem(
+        icon: Icons.visibility,
+        label: l10n?.repoWatchers ?? WordingData.repoWatchers,
+        value: _formatNumber(context, repository.watchersCount),
+      ),
+      _InfoRowItem(
+        icon: Icons.call_split,
+        label: l10n?.repoForks ?? WordingData.repoForks,
+        value: _formatNumber(context, repository.forksCount),
+      ),
+      _InfoRowItem(
+        icon: Icons.error_outline,
+        label: l10n?.repoIssues ?? WordingData.repoIssues,
+        value: _formatNumber(context, repository.openIssuesCount),
+      ),
+    ];
+  }
+
+  String _formatNumber(BuildContext context, int number) {
+    final localeString = Localizations.localeOf(context).toString();
+    return NumberFormat.compact(locale: localeString).format(number);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリ情報項目のデータクラス
+class _InfoRowItem {
+  const _InfoRowItem({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+}
+
+/// リポジトリ情報項目を表示するウィジェット
+///
+/// アイコン、ラベル、値を横並びで表示
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.item});
+
+  final _InfoRowItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card.filled(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            Icon(
+              item.icon,
+              size: 20,
+            ),
+            const SizedBox(width: 18),
+            Expanded(
+              child: Text(
+                item.label,
+                style: Theme.of(context).textTheme.bodyMedium,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              item.value,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<_InfoRowItem>('item', item));
+  }
+}
+
+/// リポジトリのタイトルを表示するウィジェット
+///
+/// タイトルは太字で、最大2行まで表示
+/// オーバーフロー時は省略記号を表示
+/// テキストは中央揃え
+class _RepositoryTitle extends StatelessWidget {
+  const _RepositoryTitle({required this.repository});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      repository.name,
+      style: theme.textTheme.headlineSmall?.copyWith(
+        fontWeight: FontWeight.bold,
+      ),
+      overflow: TextOverflow.ellipsis,
+      maxLines: 2,
+      textAlign: TextAlign.center,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -56,34 +56,40 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
       itemCount: repositories.length,
       itemBuilder: (context, index) {
         final repository = repositories[index];
-        return Card(
-          margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          child: ListTile(
-            leading:
-                repository.owner == null
-                    ? const CircleAvatar(
-                      backgroundColor: Colors.grey,
-                      child: Icon(Icons.person, color: Colors.white),
-                    )
-                    : CircleAvatar(
-                      backgroundColor: const Color(0x00000000),
-                      backgroundImage: NetworkImage(
-                        repository.owner!.avatarUrl,
+        return Hero(
+          // ヒーローアニメーションを使用してリポジトリのリストを表示
+          // 詳細画面のHeroと同一のタグを使用することでアニメーションを実現している
+          transitionOnUserGestures: true,
+          tag: 'repository-${repository.name}',
+          child: Card(
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: ListTile(
+              leading:
+                  repository.owner == null
+                      ? const CircleAvatar(
+                        backgroundColor: Colors.grey,
+                        child: Icon(Icons.person, color: Colors.white),
+                      )
+                      : CircleAvatar(
+                        backgroundColor: const Color(0x00000000),
+                        backgroundImage: NetworkImage(
+                          repository.owner!.avatarUrl,
+                        ),
                       ),
-                    ),
-            title: Text(
-              repository.name,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+              title: Text(
+                repository.name,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
+              trailing: const Icon(Icons.chevron_right),
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              onTap: () async {
+                await GoRouter.of(
+                  context,
+                ).pushNamed('details', extra: repository);
+              },
             ),
-            trailing: const Icon(Icons.chevron_right),
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-            onTap: () async {
-              await GoRouter.of(
-                context,
-              ).pushNamed('details', extra: repository);
-            },
           ),
         );
       },

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
 
 class SearchResultListView extends ConsumerStatefulWidget {
@@ -78,15 +79,10 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
             ),
             trailing: const Icon(Icons.chevron_right),
             contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-            onTap: () {
-              // TODO: リポジトリ詳細画面への遷移実装
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    'Tapped on ${repository.name}',
-                  ),
-                ),
-              );
+            onTap: () async {
+              await GoRouter.of(
+                context,
+              ).pushNamed('details', extra: repository);
             },
           ),
         );

--- a/test/unit/view/page/repositori_search_page_test.dart
+++ b/test/unit/view/page/repositori_search_page_test.dart
@@ -1,13 +1,40 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/page/repositori_search_page.dart';
 
 import '../../../mock/mock_shared_preferences_async_plarform.dart';
 import '../../../util/test_util.dart';
 
 void main() {
-  group('リポジトリ検索ページのテスト', () {
+  group('RepositorySearchPage', () {
+    testWidgets('AppBarタイトル・検索テキストボックス・リストが表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: [
+              Locale('ja'),
+              Locale('en'),
+            ],
+            locale: Locale('ja'),
+            home: RepositorySearchPage(),
+          ),
+        ),
+      );
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byType(Expanded), findsOneWidget);
+      expect(find.textContaining('リポジトリ'), findsWidgets);
+    });
     setUp(() {
       SharedPreferencesAsyncPlatform.instance =
           MockSharedPreferencesAsyncPlatform();

--- a/test/unit/view/page/repository_details_page_test.dart
+++ b/test/unit/view/page/repository_details_page_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/repository_details_page.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_card.dart';
+
+void main() {
+  group('RepositoryDetailsPage', () {
+    testWidgets('AppBarタイトルと戻るボタン、RepositoryDetailsCardが表示される', (tester) async {
+      const repository = Repository(
+        name: 'test_repo',
+        language: 'Dart',
+        stargazersCount: 10,
+        watchersCount: 5,
+        forksCount: 2,
+        openIssuesCount: 1,
+      );
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: [
+            Locale('ja'),
+            Locale('en'),
+          ],
+          locale: Locale('ja'),
+          home: RepositoryDetailsPage(repository: repository),
+        ),
+      );
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(IconButton), findsOneWidget);
+      expect(find.byType(RepositoryDetailsCard), findsOneWidget);
+      expect(find.textContaining('リポジトリ'), findsWidgets);
+    });
+  });
+}

--- a/test/unit/view/page/search_page_test.dart
+++ b/test/unit/view/page/search_page_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
-import 'package:yumemi_flutter_engineer_codecheck/view/page/search_page.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/repositori_search_page.dart';
 
 import '../../../mock/mock_shared_preferences_async_plarform.dart';
 import '../../../util/test_util.dart';
@@ -16,7 +16,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('ja'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       expect(find.text('リポジトリ検索'), findsOneWidget);
     });
@@ -24,7 +24,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('en'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       expect(find.text('Search Repository'), findsOneWidget);
     });
@@ -32,7 +32,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('ja'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       // テキストボックスに入力
       const inputText = 'Flutter';
@@ -47,7 +47,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('ja'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       // テキスト入力
       const inputText = 'Flutter';
@@ -67,13 +67,13 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('en'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       expect(find.text('Search repositories'), findsOneWidget);
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('ja'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       expect(find.text('リポジトリを検索'), findsOneWidget);
     });

--- a/test/unit/view/widget/custom_drawer_test.dart
+++ b/test/unit/view/widget/custom_drawer_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
-import 'package:yumemi_flutter_engineer_codecheck/view/page/search_page.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/page/repositori_search_page.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/custom_drawer.dart';
 
 import '../../../mock/mock_shared_preferences_async_plarform.dart';
@@ -21,7 +21,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('ja'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       // Drawerを開く
       await tester.tap(find.byIcon(Icons.menu));
@@ -34,7 +34,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('en'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
       // Drawerを開く
       await tester.tap(find.byIcon(Icons.menu));
@@ -47,7 +47,7 @@ void main() {
       await pumpAppWithLocale(
         tester: tester,
         locale: const Locale('en'),
-        home: const SearchPage(),
+        home: const RepositorySearchPage(),
       );
 
       // Drawerを開く

--- a/test/unit/view/widget/repository_details_card_test.dart
+++ b/test/unit/view/widget/repository_details_card_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_card.dart';
+
+void main() {
+  group('RepositoryDetailsCard', () {
+    testWidgets('リポジトリ情報が正しく表示される', (tester) async {
+      const repository = Repository(
+        name: 'test_repo',
+        language: 'Dart',
+        stargazersCount: 10,
+        watchersCount: 5,
+        forksCount: 2,
+        openIssuesCount: 1,
+      );
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: [
+            Locale('ja'),
+            Locale('en'),
+          ],
+          locale: Locale('ja'),
+          home: Scaffold(
+            body: RepositoryDetailsCard(repository: repository),
+          ),
+        ),
+      );
+      expect(find.text('test_repo'), findsOneWidget);
+      expect(find.text('Dart'), findsOneWidget);
+      expect(find.text('10'), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+      expect(find.text('2'), findsOneWidget);
+      expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('オーナー情報がnullの場合はデフォルトアイコンが表示される', (tester) async {
+      const repository = Repository(
+        name: 'test_repo',
+        language: 'Dart',
+        stargazersCount: 10,
+        watchersCount: 5,
+        forksCount: 2,
+        openIssuesCount: 1,
+      );
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: RepositoryDetailsCard(repository: repository),
+        ),
+      );
+      expect(find.byIcon(Icons.person), findsOneWidget);
+    });
+
+    testWidgets('オーナー情報のavatarUrlが空の場合もデフォルトアイコンが表示される', (tester) async {
+      const repository = Repository(
+        name: 'test_repo',
+        language: 'Dart',
+        stargazersCount: 10,
+        watchersCount: 5,
+        forksCount: 2,
+        openIssuesCount: 1,
+        owner: Owner(avatarUrl: ''),
+      );
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: RepositoryDetailsCard(repository: repository),
+        ),
+      );
+      expect(find.byIcon(Icons.person), findsOneWidget);
+    });
+
+    testWidgets('スター数などが大きい場合はNumberFormatで省略表示される', (tester) async {
+      const repository = Repository(
+        name: 'test_repo',
+        language: 'Dart',
+        stargazersCount: 12345,
+        watchersCount: 67890,
+        forksCount: 23456,
+        openIssuesCount: 78901,
+      );
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: RepositoryDetailsCard(repository: repository),
+        ),
+      );
+      // "12K"や"67K"など省略表記が含まれるか
+      expect(find.textContaining('K'), findsWidgets);
+    });
+
+    testWidgets('画面幅600以上で横レイアウト、未満で縦レイアウト', (tester) async {
+      const repository = Repository(
+        name: 'test_repo',
+        language: 'Dart',
+        stargazersCount: 10,
+        watchersCount: 5,
+        forksCount: 2,
+        openIssuesCount: 1,
+      );
+      // 横レイアウト
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(size: Size(700, 800)),
+            child: RepositoryDetailsCard(repository: repository),
+          ),
+        ),
+      );
+      expect(find.byType(Row), findsWidgets);
+      // 縦レイアウト
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(size: Size(400, 800)),
+            child: RepositoryDetailsCard(repository: repository),
+          ),
+        ),
+      );
+      expect(find.byType(Column), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

リポジトリの詳細情報を表示するページの実装

## 関連Issue

#53 

## 変更内容

### 主な内容

- リポジトリ検索ページの新規追加
  - lib/view/page/repositori_search_page.dart
  - test/unit/view/page/repositori_search_page_test.dart

- リポジトリ詳細ページの新規追加
  - lib/view/page/repository_details_page.dart
  - test/unit/view/page/repository_details_page_test.dart

- リポジトリ詳細カードウィジェットの新規追加
  - lib/view/widget/repository_details_card.dart
  - test/unit/view/widget/repository_details_card_test.dart

- ルーティングの追加・更新（リポジトリ詳細ページ遷移対応）
  - lib/provider/go_router_provider.dart

- 検索結果リストのUI・ロジック拡充（詳細ページ遷移・Heroアニメーション対応）
  - lib/view/widget/search_result_list_view.dart
  - test/unit/view/widget/search_result_list_view_test.dart

- 文言データ・ローカライズ対応の拡充
  - lib/static/wording_data.dart
  - lib/l10n/app_en.arb
  - lib/l10n/app_ja.arb
  - lib/l10n/app_localizations.dart
  - lib/l10n/app_localizations_en.dart
  - lib/l10n/app_localizations_ja.dart
  - lib/l10n/strings.csv

- テストコードの追加・拡充
  - test/unit/view/page/repositori_search_page_test.dart
  - test/unit/view/page/repository_details_page_test.dart
  - test/unit/view/widget/repository_details_card_test.dart
  - test/unit/view/widget/search_result_list_view_test.dart

## 動作確認内容

<!-- 動作確認した内容や手順を記載してください -->

## 補足

### 留意点

- 検索画面と詳細画面の遷移でアニメーションを行なっている
  - AppBar周りのFadeTransitionはGoRouterで実現
  - Body周りは Hero によって実現（検索画面のListViewと詳細画面のCardに同じtagのHeroを割り当てた）
  - また上記２つのDurationは合わせるように実装している

- lib/view/widget/repository_details_card.dart
  - レスポンシブな縦横レイアウト切り替え
  - オーナーアイコンのネットワーク画像・ローディング・エラー時のデフォルト表示
  - 各種情報（スター数等）の省略表記(NumberFormat)、アイコン付き表示

- lib/view/widget/search_result_list_view.dart
  - 非同期状態（ローディング・エラー・空リスト）対応、リストタップで詳細ページ遷移、Heroアニメーション対応。

- lib/provider/go_router_provider.dart
  - 検索ページ→詳細ページへの遷移、Heroアニメーション付き遷移、Repositoryオブジェクトの受け渡し。

