### PR TITLE
クエリ文字列のURLエンコードを追加

### DIFF
--- a/lib/domain/model/git_hub_search_api/git_hub_search_query.dart
+++ b/lib/domain/model/git_hub_search_api/git_hub_search_query.dart
@@ -83,11 +83,17 @@ class GitHubSearchQuery {
 
   Map<String, String> toQueryParameters() {
     return {
-      'q': q,
-      if (sort != null) 'sort': sort!.value,
-      if (order != null) 'order': order!.value,
-      if (perPage != null) 'per_page': perPage!.value.toString(),
-      if (page != null) 'page': page!.value.toString(),
+      'q': Uri.encodeQueryComponent(q),
+      if (sort != null) 'sort': Uri.encodeQueryComponent(sort!.value),
+      if (order != null) 'order': Uri.encodeQueryComponent(order!.value),
+      if (perPage != null)
+        'per_page': Uri.encodeQueryComponent(
+          perPage!.value.toString(),
+        ),
+      if (page != null)
+        'page': Uri.encodeQueryComponent(
+          page!.value.toString(),
+        ),
     };
   }
 }

--- a/test/domain/model/git_hub_search_api/git_hub_search_query_test.dart
+++ b/test/domain/model/git_hub_search_api/git_hub_search_query_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/git_hub_search_query.dart';
+
+void main() {
+  group('GitHubSearchQuery.toQueryParameters', () {
+    test('q, sort, order, perPage, pageが正しくエンコードされる', () {
+      const query = GitHubSearchQuery(
+        q: 'flutter test/テスト value',
+        sort: GitHubSearchSort.helpWantedIssues,
+        order: GitHubSearchOrder.asc,
+        perPage: PerPage(42),
+        page: PageNumber(3),
+      );
+      final params = query.toQueryParameters();
+      expect(params['q'], Uri.encodeQueryComponent('flutter test/テスト value'));
+      expect(params['sort'], Uri.encodeQueryComponent('help-wanted-issues'));
+      expect(params['order'], Uri.encodeQueryComponent('asc'));
+      expect(params['per_page'], Uri.encodeQueryComponent('42'));
+      expect(params['page'], Uri.encodeQueryComponent('3'));
+    });
+
+    test('qのみ指定した場合も正しくエンコードされる', () {
+      const query = GitHubSearchQuery(q: r'a b/c\d');
+      final params = query.toQueryParameters();
+      expect(params['q'], Uri.encodeQueryComponent(r'a b/c\d'));
+      expect(params.containsKey('sort'), false);
+      expect(params.containsKey('order'), false);
+      expect(params.containsKey('per_page'), false);
+      expect(params.containsKey('page'), false);
+    });
+
+    test('特殊文字が正しくエンコードされる（パラメタライズドテスト）', () {
+      final testCases = <String, String>{
+        'a b': Uri.encodeQueryComponent('a b'),
+        r'a\b': Uri.encodeQueryComponent(r'a\b'), // バックスラッシュ2つで1つ分
+        'a@b': Uri.encodeQueryComponent('a@b'),
+        'a+b': Uri.encodeQueryComponent('a+b'),
+        'a&b': Uri.encodeQueryComponent('a&b'),
+        'a/b': Uri.encodeQueryComponent('a/b'),
+        'a?b': Uri.encodeQueryComponent('a?b'),
+        'a=b': Uri.encodeQueryComponent('a=b'),
+        'a#b': Uri.encodeQueryComponent('a#b'),
+        'a%20b': Uri.encodeQueryComponent('a%20b'),
+        "a:;,.!~*'()": Uri.encodeQueryComponent("a:;,.!~*'()"),
+      };
+      testCases.forEach((input, expected) {
+        final query = GitHubSearchQuery(q: input);
+        final params = query.toQueryParameters();
+        expect(params['q'], expected, reason: 'input: $input');
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 概要

クエリ文字列のURLエンコードを追加

## 関連Issue

#54 

## 変更内容

エラーが発生していたのはURLエンコードしてなかったせいだった。
クエリ文字列にURL.encodeQueryComponent()を施した。

## 動作確認内容

- 手動テストの実施（半角スペースやバックスラッシュなどでエラーが発生しないこと）
- 自動テストの実施（URLエンコードが正しく行われること（ちょっとやりすぎテスト感はあるが、、、））

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
