### PR TITLE
Feature/UI design

### DIFF
--- a/docs/UIデザイン.drawio
+++ b/docs/UIデザイン.drawio
@@ -1,829 +1,682 @@
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.0.9" pages="4">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.1.6" pages="4">
   <diagram id="FU8lBgzXBYsJgkfCLfBr" name="検索画面">
-    <mxGraphModel dx="9507" dy="5180" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="3264" dy="2424" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ検索画面&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="80" y="90" width="1920" height="50" as="geometry" />
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-30" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="170" y="189" width="1920" height="980" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="80" y="140" width="1920" height="980" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ検索画面&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="170" y="139" width="1920" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-30" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="2230" y="140" width="1920" height="980" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-2" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=52;strokeWidth=0;" parent="1" vertex="1">
+          <mxGeometry x="200" y="229" width="50" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-32" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="952.5" y="170" width="605" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-5" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" parent="1" vertex="1">
+          <mxGeometry x="828.75" y="219" width="605" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-38" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="970" y="187" width="20" height="30" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-6" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="846.25" y="236" width="20" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-35" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="3NQUQ22dUql_FlJT8KjB-38">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-7" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-6" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="20" y="30" as="sourcePoint" />
             <mxPoint x="10" y="10" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-34" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="3NQUQ22dUql_FlJT8KjB-38">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-8" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-6" vertex="1">
           <mxGeometry width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-40" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
-          <mxGeometry x="1510" y="187" width="30" height="30" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-9" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" parent="1" vertex="1">
+          <mxGeometry x="1386.25" y="236" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-42" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="1020" y="172" width="470" height="58" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-10" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" parent="1" vertex="1">
+          <mxGeometry x="896.25" y="221" width="470" height="58" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="330" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-11" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="380" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="493" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-12" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="543" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="574" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-13" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="624" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="819" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-14" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="869" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="900" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-15" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="950" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="737" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-16" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="787" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="656" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-17" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="706" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="950" y="411" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-18" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="490" y="461" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="950" y="250" width="607.5" height="60" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-19" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" parent="1" vertex="1">
+          <mxGeometry x="490" y="300" width="607.5" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-10" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="970" y="260" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-20" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="510" y="310" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-20" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-12" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-22" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-20" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-13" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="340" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-23" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="390" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-23" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-15" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-25" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-23" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-16" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="421" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-26" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="471" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-27" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-26" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-18" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-28" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-26" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-19" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="503" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-29" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="553" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-30" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-29" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-21" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-31" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-29" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-22" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="584" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-32" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="634" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-33" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-32" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-24" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-34" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-32" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-25" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="666" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-35" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="716" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-36" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-35" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-27" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-37" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-35" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-28" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="747" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-38" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="797" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-39" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-38" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-30" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-40" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-38" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-31" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="829" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-41" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="879" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-42" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-41" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-33" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-43" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-41" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-34" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="968.75" y="910" width="570" height="40" as="geometry" />
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-44" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="508.75" y="960" width="570" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-45" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-44" vertex="1">
           <mxGeometry width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-36" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-46" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-44" vertex="1">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ検索画面&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="2230" y="90" width="1920" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-2" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=52;strokeWidth=0;" vertex="1" parent="1">
-          <mxGeometry x="2260" y="180" width="50" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-5" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="2888.75" y="170" width="605" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-6" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2906.25" y="187" width="20" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-7" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-6">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="20" y="30" as="sourcePoint" />
-            <mxPoint x="10" y="10" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-8" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-6">
-          <mxGeometry width="20" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-9" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
-          <mxGeometry x="3446.25" y="187" width="30" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-10" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="2956.25" y="172" width="470" height="58" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-11" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="330" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-12" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="493" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-13" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="574" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-14" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="819" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-15" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="900" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-16" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="737" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-17" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="656" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-18" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="411" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-19" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="2886.25" y="250" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-20" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2906.25" y="260" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-20">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-22" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-20">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-23" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="340" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-23">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-25" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-23">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-26" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="421" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-27" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-26">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-28" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-26">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-29" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="503" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-30" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-29">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-31" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-29">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-32" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="584" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-33" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-32">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-34" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-32">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-35" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="666" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-36" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-35">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-37" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-35">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-38" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="747" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-39" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-38">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-40" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-38">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-41" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="829" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-42" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-41">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-43" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-41">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-44" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="910" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-45" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-44">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-46" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-44">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-47" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-47" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="170" y="1425" width="380" height="665" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-55" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-55" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="190" y="1585" width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-48" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-55">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-48" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-55" vertex="1">
           <mxGeometry width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-50" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-55">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-50" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-55" vertex="1">
           <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-51" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-55">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-51" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-55" vertex="1">
           <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-56" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-56" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="190" y="1665" width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-57" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-56">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-57" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-56" vertex="1">
           <mxGeometry width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-58" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-56">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-58" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-56" vertex="1">
           <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-59" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-56">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-59" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-56" vertex="1">
           <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-60" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-60" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="190" y="1745" width="340" height="343" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-61" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-60">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-61" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-60" vertex="1">
           <mxGeometry width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-62" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-60">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-62" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-60" vertex="1">
           <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-63" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-60">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-63" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-60" vertex="1">
           <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-64" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-64" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="190" y="1829" width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-65" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-64">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-65" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-64" vertex="1">
           <mxGeometry width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-66" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-64">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-66" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-64" vertex="1">
           <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-67" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-64">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-67" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-64" vertex="1">
           <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-68" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-68" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="190" y="1915" width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-69" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-68">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-69" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-68" vertex="1">
           <mxGeometry width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-70" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-68">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-70" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-68" vertex="1">
           <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-71" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-68">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-71" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-68" vertex="1">
           <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-72" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-72" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="190" y="1995" width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-73" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-72">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-73" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-72" vertex="1">
           <mxGeometry width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-74" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-72">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-74" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-72" vertex="1">
           <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-75" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-72">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-75" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-72" vertex="1">
           <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-80" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-80" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" parent="1" vertex="1">
           <mxGeometry x="170" y="1425" width="380" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-81" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-81" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" parent="1" vertex="1">
           <mxGeometry x="190" y="1447.5" width="35" height="35" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-82" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-82" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" parent="1" vertex="1">
           <mxGeometry x="190" y="1505" width="340" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-83" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-83" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="204" y="1523" width="20" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-84" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-83">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-84" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-83" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="20" y="30" as="sourcePoint" />
             <mxPoint x="10" y="10" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-85" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-83">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-85" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-83" vertex="1">
           <mxGeometry width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-86" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-86" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" parent="1" vertex="1">
           <mxGeometry x="490" y="1520" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-87" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;align=left;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-87" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;align=left;" parent="1" vertex="1">
           <mxGeometry x="236" y="1506" width="244" height="58" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-89" value="" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-89" value="" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" parent="1" vertex="1">
           <mxGeometry x="1692.82" y="1255.94" width="371.87" height="670" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-90" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-90" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" parent="1" vertex="1">
           <mxGeometry x="1548.75" y="1406" width="660" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-91" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-91" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" parent="1" vertex="1">
           <mxGeometry x="1553.75" y="1418.5" width="35" height="35" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-92" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-92" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="2018.75" y="1423" width="20" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-93" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-92">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-93" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-92" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="20" y="30" as="sourcePoint" />
             <mxPoint x="10" y="10" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-94" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-92">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-94" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-92" vertex="1">
           <mxGeometry width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-133" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-133" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1578.75" y="1562" width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-134" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-133">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-134" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-133" vertex="1">
           <mxGeometry width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-135" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-133">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-135" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-133" vertex="1">
           <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-136" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-133">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-136" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-133" vertex="1">
           <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-137" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-137" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1578.75" y="1632" width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-138" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-137">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-138" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-137" vertex="1">
           <mxGeometry width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-139" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-137">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-139" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-137" vertex="1">
           <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-140" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-137">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-140" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-137" vertex="1">
           <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-141" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-141" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1578.75" y="1702" width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-142" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-141">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-142" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-141" vertex="1">
           <mxGeometry width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-143" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-141">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-143" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-141" vertex="1">
           <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-144" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-141">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-144" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-141" vertex="1">
           <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-145" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-145" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1888.75" y="1562" width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-146" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-145">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-146" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-145" vertex="1">
           <mxGeometry width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-147" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-145">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-147" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-145" vertex="1">
           <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-148" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-145">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-148" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-145" vertex="1">
           <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-149" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-149" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1888.75" y="1632" width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-150" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-149">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-150" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-149" vertex="1">
           <mxGeometry width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-151" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-149">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-151" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-149" vertex="1">
           <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-152" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-149">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-152" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-149" vertex="1">
           <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-153" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-153" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1888.75" y="1702" width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-154" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-153">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-154" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" parent="LQzH_NDQMfFLRa0uXr-V-153" vertex="1">
           <mxGeometry width="290" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-155" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-153">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-155" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="LQzH_NDQMfFLRa0uXr-V-153" vertex="1">
           <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-156" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-153">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-156" value="" style="triangle;whiteSpace=wrap;html=1;" parent="LQzH_NDQMfFLRa0uXr-V-153" vertex="1">
           <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-163" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-163" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" parent="1" vertex="1">
           <mxGeometry x="1576.25" y="1484" width="605" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-164" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-164" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1593.75" y="1501" width="20" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-165" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-164">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-165" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-164" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="20" y="30" as="sourcePoint" />
             <mxPoint x="10" y="10" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-166" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-164">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-166" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" parent="LQzH_NDQMfFLRa0uXr-V-164" vertex="1">
           <mxGeometry width="20" height="20" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-167" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-167" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" parent="1" vertex="1">
           <mxGeometry x="2133.75" y="1501" width="30" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-168" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-168" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" parent="1" vertex="1">
           <mxGeometry x="1643.75" y="1486" width="470" height="58" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-169" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="80" y="140" width="450" height="980" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry width="450" height="980" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-6" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="15" y="840" width="420" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-7" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="15" y="909" width="420" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-8" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="15" y="10" width="420" height="100" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-10" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="15" y="110" as="sourcePoint" />
-            <mxPoint x="435" y="110" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-19" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="40" y="140" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-20" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="350" y="150" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-21" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="40" y="225" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-22" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="40" y="310" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-23" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="40" y="395" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-24" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="40" y="480" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-25" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="350" y="235" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-26" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="350" y="320" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-27" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="350" y="405" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-28" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry x="350" y="490" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-37" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="15" y="819" as="sourcePoint" />
-            <mxPoint x="435" y="819" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-244" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-244" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="610" y="1425" width="250" height="665" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-171" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=light-dark(#FFFFFF,#FFFFFF);" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-171" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=light-dark(#FFFFFF,#FFFFFF);" parent="LQzH_NDQMfFLRa0uXr-V-244" vertex="1">
           <mxGeometry width="250" height="665" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-172" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-172" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" parent="LQzH_NDQMfFLRa0uXr-V-244" vertex="1">
           <mxGeometry x="8.340000000000032" y="573.5" width="233.33" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-173" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-173" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" parent="LQzH_NDQMfFLRa0uXr-V-244" vertex="1">
           <mxGeometry x="8.340000000000032" y="615.5" width="233.33" height="29" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-174" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-174" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" parent="LQzH_NDQMfFLRa0uXr-V-244" vertex="1">
           <mxGeometry x="8.33" y="10" width="233.33" height="70" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-175" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-175" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-244" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="8.333333333333371" y="80" as="sourcePoint" />
             <mxPoint x="241.66666666666674" y="80" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-186" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-186" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-244" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="8.333333333333371" y="555.5" as="sourcePoint" />
             <mxPoint x="241.66666666666674" y="555.5" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-187" value="" style="group" vertex="1" connectable="0" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-187" value="" style="group" parent="LQzH_NDQMfFLRa0uXr-V-244" vertex="1" connectable="0">
           <mxGeometry x="22.220000000000027" y="95" width="205.56" height="310" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-176" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-176" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-178" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-178" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry y="65.875" width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-179" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-179" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry y="131.75" width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-180" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-180" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry y="197.625" width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-181" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-181" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry y="263.5" width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-185" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-185" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry x="167.77999999999997" y="273.0615789473684" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-184" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-184" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry x="167.77999999999997" y="207.19368421052627" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-183" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-183" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry x="167.77999999999997" y="141.31578947368416" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-182" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-182" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-187" vertex="1">
           <mxGeometry x="167.77999999999997" y="75.43789473684205" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-177" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-177" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-244" vertex="1">
           <mxGeometry x="190" y="107" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-247" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=light-dark(#FFFFFF,#FFFFFF);" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-247" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=light-dark(#FFFFFF,#FFFFFF);" parent="1" vertex="1">
           <mxGeometry x="1241" y="1400" width="250" height="390" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-250" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-250" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" parent="1" vertex="1">
           <mxGeometry x="1249.33" y="1410" width="233.33" height="70" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-251" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-251" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="1249.3333333333335" y="1480" as="sourcePoint" />
             <mxPoint x="1482.6666666666667" y="1480" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-253" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-253" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1263.22" y="1495" width="219.45000000000002" height="310" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-254" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-254" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-255" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-255" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry y="65.875" width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-256" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-256" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry y="131.75" width="205.56000000000006" height="46.5" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-261" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-261" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry x="167.77999999999997" y="141.31578947368416" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-262" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-262" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry x="167.77999999999997" y="75.43789473684205" width="27.37" height="27.36842105263158" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-248" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-248" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry x="-13.879999999999995" y="213" width="233.33" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-249" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-249" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" parent="LQzH_NDQMfFLRa0uXr-V-253" vertex="1">
           <mxGeometry x="-13.879999999999995" y="255" width="233.33" height="29" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-252" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-252" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" parent="LQzH_NDQMfFLRa0uXr-V-253" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-13.886666666666656" y="195" as="sourcePoint" />
             <mxPoint x="219.44666666666672" y="195" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-263" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-263" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" parent="1" vertex="1">
           <mxGeometry x="1431" y="1507" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="380" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="543" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="624" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="869" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="950" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="787" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="706" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="461" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="1130" y="300" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-10" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1150" y="310" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-10">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-12" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-10">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-13" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="390" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-13">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-15" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-13">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-16" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="471" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-16">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-18" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-16">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-19" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="553" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-19">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-21" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-19">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-22" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="634" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-22">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-24" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-22">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-25" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="716" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-25">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-27" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-25">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-28" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="797" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-28">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-30" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-28">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-31" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="879" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-31">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-33" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-31">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-34" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1148.75" y="960" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-34">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="H0ZL44mk5dD9Fsi43VGb-36" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="H0ZL44mk5dD9Fsi43VGb-34">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>
   </diagram>
   <diagram id="2aM2A-6S-Wh7pI4XLxjm" name="詳細画面">
-    <mxGraphModel dx="4753" dy="3759" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="2720" dy="3189" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="wAwD6aCW4f1jpx36XDWf-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="wAwD6aCW4f1jpx36XDWf-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="44" y="120" width="370" height="660" as="geometry" />
         </mxCell>
-        <mxCell id="wAwD6aCW4f1jpx36XDWf-2" value="" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+        <mxCell id="wAwD6aCW4f1jpx36XDWf-2" value="" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" parent="1" vertex="1">
           <mxGeometry x="802.5" y="97.5" width="365" height="660" as="geometry" />
         </mxCell>
-        <mxCell id="wAwD6aCW4f1jpx36XDWf-3" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="wAwD6aCW4f1jpx36XDWf-3" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="44" y="120" width="370" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="655" y="240" width="660" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-4" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-4" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="1" vertex="1">
           <mxGeometry x="189" y="210" width="80" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-17" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-17" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" parent="1" vertex="1">
           <mxGeometry x="153.63" y="280" width="150.75" height="125" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-23" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-23" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="60" y="380.1" width="336" height="260" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-18" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+        <mxCell id="duIHhKJAwggp7_61a4r5-18" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="duIHhKJAwggp7_61a4r5-23" vertex="1">
           <mxGeometry y="55" width="336" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-19" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+        <mxCell id="duIHhKJAwggp7_61a4r5-19" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="duIHhKJAwggp7_61a4r5-23" vertex="1">
           <mxGeometry y="110.19230769230768" width="336" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-20" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+        <mxCell id="duIHhKJAwggp7_61a4r5-20" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="duIHhKJAwggp7_61a4r5-23" vertex="1">
           <mxGeometry y="165.38461538461536" width="336" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-21" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+        <mxCell id="duIHhKJAwggp7_61a4r5-21" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="duIHhKJAwggp7_61a4r5-23" vertex="1">
           <mxGeometry y="220.5769230769231" width="336" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-22" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+        <mxCell id="duIHhKJAwggp7_61a4r5-22" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="duIHhKJAwggp7_61a4r5-23" vertex="1">
           <mxGeometry width="336" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-26" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-26" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;" parent="1" vertex="1">
           <mxGeometry x="670" y="254.67999999999995" width="24" height="30.64" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-27" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-27" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;" parent="1" vertex="1">
           <mxGeometry x="60" y="134.67999999999995" width="24" height="30.64" as="geometry" />
         </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-12" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="60" y="720" width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-13" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-12">
-          <mxGeometry width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-14" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-12">
-          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-15" value="" style="group;flipH=1;" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="360" y="720" width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-16" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-15">
-          <mxGeometry width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-17" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;flipH=1;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-15">
-          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
-        </mxCell>
-        <mxCell id="C9AApOpk92xFXuM4X5s--1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="C9AApOpk92xFXuM4X5s--1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="40" y="-1010" width="1920" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="C9AApOpk92xFXuM4X5s--109" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="C9AApOpk92xFXuM4X5s--109" value="" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
           <mxGeometry x="40" y="-960" width="1920" height="950" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-16" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="668.75" y="-890" width="632.5" height="277.69000000000005" as="geometry" />
+        <mxCell id="H9VjxzaiKczBng6LxmAf-16" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="680" y="-890" width="632.5" height="277.69000000000005" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-16">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="H9VjxzaiKczBng6LxmAf-16" vertex="1">
           <mxGeometry x="75.38" width="80" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-18" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-16">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-18" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" parent="H9VjxzaiKczBng6LxmAf-16" vertex="1">
           <mxGeometry x="40" y="110.19" width="150.75" height="125" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-19" value="" style="group" vertex="1" connectable="0" parent="H9VjxzaiKczBng6LxmAf-16">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-19" value="" style="group" parent="H9VjxzaiKczBng6LxmAf-16" vertex="1" connectable="0">
           <mxGeometry x="230" width="340" height="260" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-20" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-20" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="H9VjxzaiKczBng6LxmAf-19" vertex="1">
           <mxGeometry y="55" width="340" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-21" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-21" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="H9VjxzaiKczBng6LxmAf-19" vertex="1">
           <mxGeometry y="110.19230769230768" width="340" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-22" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-22" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="H9VjxzaiKczBng6LxmAf-19" vertex="1">
           <mxGeometry y="165.38461538461536" width="340" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-23" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-23" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="H9VjxzaiKczBng6LxmAf-19" vertex="1">
           <mxGeometry y="220.5769230769231" width="340" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-24" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+        <mxCell id="H9VjxzaiKczBng6LxmAf-24" value="" style="rounded=1;whiteSpace=wrap;html=1;" parent="H9VjxzaiKczBng6LxmAf-19" vertex="1">
           <mxGeometry width="340" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-25" value="" style="group" vertex="1" connectable="0" parent="H9VjxzaiKczBng6LxmAf-16">
-          <mxGeometry y="235.19000000000005" width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-25">
-          <mxGeometry width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-27" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-25">
-          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
-        </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-28" value="" style="group;flipH=1;" vertex="1" connectable="0" parent="H9VjxzaiKczBng6LxmAf-16">
-          <mxGeometry x="590" y="235" width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-28">
-          <mxGeometry width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="H9VjxzaiKczBng6LxmAf-30" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;flipH=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-28">
-          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
-        </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-3" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-3" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" parent="1" vertex="1">
           <mxGeometry x="785.38" y="325" width="80" height="80" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-5" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-5" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" parent="1" vertex="1">
           <mxGeometry x="750" y="435.19" width="150.75" height="125" as="geometry" />
         </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-6" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="670" y="560.19" width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-7" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-6">
-          <mxGeometry width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-8" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-6">
-          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-9" value="" style="group;flipH=1;" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="1260" y="560" width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-10" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-9">
-          <mxGeometry width="42.5" height="42.5" as="geometry" />
-        </mxCell>
-        <mxCell id="P5SM2VEQe3d-N8lNLVMV-11" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;flipH=1;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-9">
-          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
-        </mxCell>
-        <mxCell id="4C3NyFkav0wo-2EBLAcl-1" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="4C3NyFkav0wo-2EBLAcl-1" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="940" y="325" width="280" height="260" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-6" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-6" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" parent="4C3NyFkav0wo-2EBLAcl-1" vertex="1">
           <mxGeometry y="55" width="280" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-12" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-12" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" parent="4C3NyFkav0wo-2EBLAcl-1" vertex="1">
           <mxGeometry y="110.19230769230768" width="280" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-13" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-13" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" parent="4C3NyFkav0wo-2EBLAcl-1" vertex="1">
           <mxGeometry y="165.38461538461536" width="280" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-14" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-14" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" parent="4C3NyFkav0wo-2EBLAcl-1" vertex="1">
           <mxGeometry y="220.5769230769231" width="280" height="39.42307692307692" as="geometry" />
         </mxCell>
-        <mxCell id="duIHhKJAwggp7_61a4r5-16" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+        <mxCell id="duIHhKJAwggp7_61a4r5-16" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" parent="4C3NyFkav0wo-2EBLAcl-1" vertex="1">
           <mxGeometry width="280" height="39.42307692307692" as="geometry" />
-        </mxCell>
-        <mxCell id="4C3NyFkav0wo-2EBLAcl-2" value="a" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=12;" edge="1" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="970" y="298.31" as="sourcePoint" />
-            <mxPoint x="970" y="-584" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="4C3NyFkav0wo-2EBLAcl-3" value="同じウィジェット" style="edgeLabel;resizable=0;html=1;;align=center;verticalAlign=middle;fontSize=72;" connectable="0" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-2">
-          <mxGeometry relative="1" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/docs/UIデザイン.drawio
+++ b/docs/UIデザイン.drawio
@@ -1,0 +1,199 @@
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.0.9">
+  <diagram name="Page-1" id="c9db0220-8083-56f3-ca83-edcdcd058819">
+    <mxGraphModel dx="1408" dy="748" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1.5" pageWidth="826" pageHeight="1169" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="0" style=";html=1;" />
+        <mxCell id="1" style=";html=1;" parent="0" />
+        <mxCell id="3d76a8aef4d5c911-1" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;fillColor=#222222;strokeColor=none;whiteSpace=wrap;rounded=0;fontSize=12;fontColor=#000000;align=center;" parent="1" vertex="1">
+          <mxGeometry x="40" y="70" width="1150" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-2" value="Company" style="html=1;shadow=0;dashed=0;fillColor=none;strokeColor=none;shape=mxgraph.bootstrap.rect;fontColor=#999999;fontSize=14;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry width="115" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-3" value="People" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;fillColor=#000000;strokeColor=none;fontColor=#ffffff;spacingRight=30;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry x="115" width="129.375" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-4" value="84" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=8;fillColor=#ff0000;strokeColor=none;fontColor=#ffffff;whiteSpace=wrap;" parent="3d76a8aef4d5c911-3" vertex="1">
+          <mxGeometry x="1" y="0.5" width="25" height="16" relative="1" as="geometry">
+            <mxPoint x="-30" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-5" value="Violations" style="html=1;shadow=0;dashed=0;fillColor=none;strokeColor=none;shape=mxgraph.bootstrap.rect;fontColor=#999999;spacingRight=30;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry x="244.375" width="158.125" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-6" value="42" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=8;fillColor=#ff0000;strokeColor=none;fontColor=#ffffff;whiteSpace=wrap;" parent="3d76a8aef4d5c911-5" vertex="1">
+          <mxGeometry x="1" y="0.5" width="25" height="16" relative="1" as="geometry">
+            <mxPoint x="-30" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-7" value="Statistics" style="html=1;shadow=0;dashed=0;fillColor=none;strokeColor=none;shape=mxgraph.bootstrap.rect;fontColor=#999999;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry x="402.5" width="115" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-8" value="Settings" style="html=1;shadow=0;dashed=0;fillColor=none;strokeColor=none;shape=mxgraph.bootstrap.rect;fontColor=#999999;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry x="517.5" width="100.625" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-9" value="Profile" style="html=1;shadow=0;dashed=0;fillColor=none;strokeColor=none;shape=mxgraph.bootstrap.rect;fontColor=#999999;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry x="948.75" width="100.625" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-10" value="Log Out" style="html=1;shadow=0;dashed=0;fillColor=none;strokeColor=none;shape=mxgraph.bootstrap.rect;fontColor=#999999;whiteSpace=wrap;" parent="3d76a8aef4d5c911-1" vertex="1">
+          <mxGeometry x="1049.375" width="100.625" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-11" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=#dddddd;rounded=0;fontSize=12;align=center;" parent="1" vertex="1">
+          <mxGeometry x="860" y="150" width="330" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-12" value="320x200" style="shape=rect;fontSize=24;fillColor=#f0f0f0;strokeColor=none;fontColor=#999999;whiteSpace=wrap;" parent="3d76a8aef4d5c911-11" vertex="1">
+          <mxGeometry x="5" y="5" width="320" height="200" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-13" value="Thumbnail label" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.anchor;fontSize=26;align=left;whiteSpace=wrap;" parent="3d76a8aef4d5c911-11" vertex="1">
+          <mxGeometry x="15" y="220" width="300" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-14" value="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit." style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.anchor;strokeColor=#dddddd;whiteSpace=wrap;align=left;verticalAlign=top;fontSize=14;whiteSpace=wrap;" parent="3d76a8aef4d5c911-11" vertex="1">
+          <mxGeometry x="15" y="260" width="300" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-15" value="Button" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;fontSize=16;fillColor=#3D8BCD;strokeColor=none;fontColor=#ffffff;whiteSpace=wrap;" parent="3d76a8aef4d5c911-11" vertex="1">
+          <mxGeometry y="1" width="80" height="40" relative="1" as="geometry">
+            <mxPoint x="15" y="-60" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-16" value="Button" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;fontSize=16;strokeColor=#dddddd;whiteSpace=wrap;" parent="3d76a8aef4d5c911-11" vertex="1">
+          <mxGeometry y="1" width="80" height="40" relative="1" as="geometry">
+            <mxPoint x="100" y="-60" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-17" value="Template name" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="130" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-18" value="Uncompleted Profile" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=#dddddd;;align=left;spacingLeft=10;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="150" width="800" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-19" value="Subject" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="210" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-20" value="Hello, %USER_FULL_NAME%" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=#dddddd;align=left;spacingLeft=10;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="230" width="800" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-21" value="Insert System Variable" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;align=right;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="690" y="210" width="120" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-22" value="" style="shape=triangle;strokeColor=none;fillColor=#000000;direction=south;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;html=1;" parent="1" vertex="1">
+          <mxGeometry x="812" y="217" width="8" height="4" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-23" value="Message" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="290" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-24" value="Hello %USER_FULL_NAME%!&#xa;&#xa;At vero eos et accusamus et iusto odio dignissimos ducimus, qui blanditiis praesentium voluptatum deleniti atque corrupti, quosdolores et quas molestias excepturi sint, obcaecati cupiditate non provident, similique sunt in culpa, qui officia deserunt mollitiaanimi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum solutanobis est eligendi optio, cumque nihil impedit, quo minus id, quod maxime placeat, facere possimus, omnis voluptas assumendaest, omnis dolor repellendus." style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;fontSize=12;strokeColor=#dddddd;align=left;spacing=10;verticalAlign=top;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="310" width="800" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-25" value="Insert System Variable" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;align=right;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="690" y="290" width="120" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-26" value="" style="shape=triangle;strokeColor=none;fillColor=#000000;direction=south;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;html=1;" parent="1" vertex="1">
+          <mxGeometry x="812" y="297" width="8" height="4" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-27" value="%USER_FULL_NAME%&#xa;%USER_EMAIL%&#xa;%USER_PROFILE_COMPLETENESS%&#xa;%USER_NUM_SUCCESS_TRADES%&#xa;%USER_FULL_NAME%&#xa;%USER_EMAIL%&#xa;%USER_PROFILE_COMPLETENESS%&#xa;%USER_NUM_SUCCESS_SELLS%" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;fontSize=12;rSize=2;strokeColor=#dddddd;align=left;verticalAlign=top;spacing=10;shadow=1;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="590" y="305" width="240" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-28" value="Message Type" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="570" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-29" value="Email + Push" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=#dddddd;align=left;spacingLeft=10;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="590" width="390" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-30" value="" style="shape=triangle;strokeColor=none;fillColor=#000000;direction=south;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;html=1;" parent="1" vertex="1">
+          <mxGeometry x="410" y="607" width="10" height="5" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-31" value="Tap target" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="450" y="570" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-32" value="Profile Screen" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=#dddddd;align=left;spacingLeft=10;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="450" y="590" width="390" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-33" value="" style="shape=triangle;strokeColor=none;fillColor=#000000;direction=south;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;html=1;" parent="1" vertex="1">
+          <mxGeometry x="820" y="607" width="10" height="5" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-34" value="Send to Group" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="650" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-35" value="Top Management" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.checkbox;fontSize=12;strokeColor=#999999;align=left;labelPosition=right;spacingLeft=5;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="50" y="673" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-36" value="Marketing Department" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;fontSize=12;rSize=3;strokeColor=#999999;align=left;labelPosition=right;spacingLeft=5;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="50" y="693" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-37" value="Design Department" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.checkbox;fontSize=12;strokeColor=#999999;align=left;labelPosition=right;spacingLeft=5;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="50" y="713" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-38" value="Financial Department" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;fontSize=12;rSize=3;strokeColor=#999999;align=left;labelPosition=right;spacingLeft=5;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="50" y="733" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-39" value="Supply Department" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;fontSize=12;rSize=3;strokeColor=#999999;align=left;labelPosition=right;spacingLeft=5;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="50" y="753" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-40" value="Set Type" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rect;strokeColor=none;fillColor=none;fontColor=#999999;align=left;spacingLeft=5;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="450" y="650" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-41" value="" style="shape=ellipse;dashed=0;strokeColor=#999999;fillColor=#ffffff;html=1;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;" parent="1" vertex="1">
+          <mxGeometry x="460" y="673" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-42" value="News" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=3;strokeColor=none;fillColor=#58B957;fontColor=#ffffff;fontStyle=1;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="480" y="673" width="40" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-43" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.radioButton;strokeColor=#999999;fillColor=#ffffff;rounded=0;fontSize=12;fontColor=#000000;align=center;" parent="1" vertex="1">
+          <mxGeometry x="460" y="693" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-44" value="Reports" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=3;strokeColor=none;fillColor=#55BFE0;fontColor=#ffffff;fontStyle=1;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="480" y="693" width="50" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-45" value="" style="shape=ellipse;dashed=0;strokeColor=#999999;fillColor=#ffffff;html=1;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;" parent="1" vertex="1">
+          <mxGeometry x="460" y="713" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-46" value="Documents" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=3;strokeColor=none;fillColor=#EFAC43;fontColor=#ffffff;fontStyle=1;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="480" y="713" width="70" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-47" value="" style="shape=ellipse;dashed=0;strokeColor=#999999;fillColor=#ffffff;html=1;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;" parent="1" vertex="1">
+          <mxGeometry x="460" y="733" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-48" value="Media" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=3;strokeColor=none;fillColor=#3D8BCD;fontColor=#ffffff;fontStyle=1;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="480" y="733" width="40" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-49" value="" style="shape=ellipse;dashed=0;strokeColor=#999999;fillColor=#ffffff;html=1;rounded=0;shadow=1;fontSize=12;fontColor=#000000;align=center;" parent="1" vertex="1">
+          <mxGeometry x="460" y="753" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-50" value="Text" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=3;strokeColor=none;fillColor=#999999;fontColor=#ffffff;fontStyle=1;fontSize=10;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="480" y="753" width="30" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-51" value="Save Template" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=5;strokeColor=none;fillColor=#3D8BCD;fontColor=#ffffff;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="40" y="810" width="150" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-52" value="Cancel" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=5;strokeColor=#dddddd;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="210" y="810" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-53" value="Delete Template" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;align=center;rSize=5;strokeColor=none;fillColor=#DB524C;fontColor=#ffffff;fontSize=16;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+          <mxGeometry x="670" y="810" width="170" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-54" value="" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;strokeColor=#dddddd;rounded=0;fontSize=12;align=center;" parent="1" vertex="1">
+          <mxGeometry x="860" y="580" width="330" height="400" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-55" value="320x200" style="shape=rect;fontSize=24;fillColor=#f0f0f0;strokeColor=none;fontColor=#999999;whiteSpace=wrap;" parent="3d76a8aef4d5c911-54" vertex="1">
+          <mxGeometry x="5" y="5" width="320" height="200" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-56" value="Thumbnail label" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.anchor;fontSize=26;align=left;whiteSpace=wrap;" parent="3d76a8aef4d5c911-54" vertex="1">
+          <mxGeometry x="15" y="220" width="300" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-57" value="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit." style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.anchor;strokeColor=#dddddd;whiteSpace=wrap;align=left;verticalAlign=top;fontSize=14;whiteSpace=wrap;" parent="3d76a8aef4d5c911-54" vertex="1">
+          <mxGeometry x="15" y="260" width="300" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-58" value="Button" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;fontSize=16;fillColor=#3D8BCD;strokeColor=none;fontColor=#ffffff;whiteSpace=wrap;" parent="3d76a8aef4d5c911-54" vertex="1">
+          <mxGeometry y="1" width="80" height="40" relative="1" as="geometry">
+            <mxPoint x="15" y="-60" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3d76a8aef4d5c911-59" value="Button" style="html=1;shadow=0;dashed=0;shape=mxgraph.bootstrap.rrect;rSize=5;fontSize=16;strokeColor=#dddddd;whiteSpace=wrap;" parent="3d76a8aef4d5c911-54" vertex="1">
+          <mxGeometry y="1" width="80" height="40" relative="1" as="geometry">
+            <mxPoint x="100" y="-60" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/UIデザイン.drawio
+++ b/docs/UIデザイン.drawio
@@ -1,4 +1,4 @@
-<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.0.9">
+<mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.0.9" pages="4">
   <diagram name="Page-1" id="c9db0220-8083-56f3-ca83-edcdcd058819">
     <mxGraphModel dx="1408" dy="748" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1.5" pageWidth="826" pageHeight="1169" background="none" math="0" shadow="0">
       <root>
@@ -192,6 +192,348 @@
           <mxGeometry y="1" width="80" height="40" relative="1" as="geometry">
             <mxPoint x="100" y="-60" as="offset" />
           </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="FU8lBgzXBYsJgkfCLfBr" name="検索画面">
+    <mxGraphModel dx="4410" dy="2483" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="80" y="70" width="1920" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="80" y="140" width="1920" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="80" y="140" width="450" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-6" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="1">
+          <mxGeometry x="95" y="980" width="420" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-7" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="1">
+          <mxGeometry x="95" y="1049" width="420" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-8" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+          <mxGeometry x="95" y="150" width="420" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-10" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="95" y="250" as="sourcePoint" />
+            <mxPoint x="515" y="250" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-19" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="120" y="280" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-20" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="430" y="290" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-21" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="120" y="365" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-22" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="120" y="450" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-23" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="120" y="535" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-24" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="120" y="620" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-25" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="430" y="375" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-26" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="430" y="460" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-27" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="430" y="545" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-28" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="430" y="630" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-30" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="530" y="140" width="1470" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-31" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=56;" vertex="1" parent="1">
+          <mxGeometry x="530" y="160" width="1470" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-32" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="962.5" y="250" width="605" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-38" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="980" y="267" width="20" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-35" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="3NQUQ22dUql_FlJT8KjB-38">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="30" as="sourcePoint" />
+            <mxPoint x="10" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-34" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="3NQUQ22dUql_FlJT8KjB-38">
+          <mxGeometry width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-40" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+          <mxGeometry x="1520" y="267" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-42" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="1030" y="252" width="470" height="58" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="410" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="573" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="654" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="899" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="980" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="817" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="736" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="491" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="960" y="330" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-10" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="980" y="340" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-12" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-13" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="420" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-15" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-16" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="501" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-18" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-19" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="583" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-21" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-22" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="664" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-24" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-25" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="746" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-27" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-28" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="827" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-30" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-31" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="909" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-33" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-34" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="990" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-36" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-37" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="95" y="959" as="sourcePoint" />
+            <mxPoint x="515" y="959" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-44" value="" style="group;strokeWidth=3;" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="490" y="190" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-45" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=3;" edge="1" parent="RbmyN5pTn8aNILAV9D3_-44">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint y="20" as="sourcePoint" />
+            <mxPoint x="20" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-46" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=3;" edge="1" parent="RbmyN5pTn8aNILAV9D3_-44">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint as="sourcePoint" />
+            <mxPoint x="20" y="9.999999999999545" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="2aM2A-6S-Wh7pI4XLxjm" name="詳細画面">
+    <mxGraphModel dx="2646" dy="1490" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="9eAIsCWrS4Yunl0qI4hi" name="comopnent">
+    <mxGraphModel dx="1323" dy="745" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="620" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="783" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="864" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1109" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1190" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1027" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="946" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="701" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="100" y="540" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-10" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="120" y="550" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-10">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-12" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-10">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-13" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="630" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-13">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-15" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-13">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-16" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="711" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-16">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-18" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-16">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-19" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="793" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-19">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-21" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-19">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-22" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="874" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-22">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-24" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-22">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-25" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="956" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-25">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-27" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-25">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-28" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="1037" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-28">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-30" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-28">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-31" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="1119" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-31">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-33" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-31">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-34" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="1200" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-34">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-36" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-34">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/docs/UIデザイン.drawio
+++ b/docs/UIデザイン.drawio
@@ -1,6 +1,795 @@
 <mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.0.9" pages="4">
+  <diagram id="FU8lBgzXBYsJgkfCLfBr" name="検索画面">
+    <mxGraphModel dx="4395" dy="3725" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="80" y="90" width="1920" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="80" y="140" width="1920" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-30" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="2230" y="140" width="1920" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-31" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=56;" vertex="1" parent="1">
+          <mxGeometry x="530" y="190" width="1470" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-32" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="962.5" y="280" width="605" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-38" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="980" y="297" width="20" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-35" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="3NQUQ22dUql_FlJT8KjB-38">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="30" as="sourcePoint" />
+            <mxPoint x="10" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-34" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="3NQUQ22dUql_FlJT8KjB-38">
+          <mxGeometry width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-40" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+          <mxGeometry x="1520" y="297" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-42" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="1030" y="282" width="470" height="58" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="440" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="603" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="684" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="929" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="1010" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="847" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="766" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="960" y="521" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="960" y="360" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-10" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="980" y="370" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-12" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-13" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="450" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-15" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-16" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="531" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-18" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-19" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="613" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-21" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-22" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="694" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-24" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-25" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="776" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-27" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-28" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="857" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-30" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-31" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="939" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-33" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-34" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="978.75" y="1020" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-36" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="2230" y="90" width="1920" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-2" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=52;strokeWidth=0;" vertex="1" parent="1">
+          <mxGeometry x="2260" y="180" width="50" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-4" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=56;" vertex="1" parent="1">
+          <mxGeometry x="2455" y="180" width="1470" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-5" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="2887.5" y="270" width="605" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-6" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2905" y="287" width="20" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-7" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-6">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="30" as="sourcePoint" />
+            <mxPoint x="10" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-8" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-6">
+          <mxGeometry width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-9" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+          <mxGeometry x="3445" y="287" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-10" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="2955" y="272" width="470" height="58" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-11" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="430" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-12" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="593" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-13" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="674" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-14" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="919" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-15" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="1000" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-16" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="837" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-17" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="756" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-18" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="511" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-19" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="2885" y="350" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-20" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2905" y="360" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-20">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-22" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-20">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-23" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="440" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-23">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-25" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-23">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-26" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="521" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-27" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-26">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-28" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-26">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-29" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="603" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-30" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-29">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-31" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-29">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-32" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="684" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-33" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-32">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-34" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-32">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-35" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="766" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-36" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-35">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-37" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-35">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-38" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="847" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-39" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-38">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-40" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-38">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-41" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="929" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-42" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-41">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-43" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-41">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-44" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2903.75" y="1010" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-45" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-44">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-46" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-44">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-47" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="170" y="1425" width="380" height="665" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-55" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="190" y="1585" width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-48" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-55">
+          <mxGeometry width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-50" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-55">
+          <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-51" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-55">
+          <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-56" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="190" y="1665" width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-57" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-56">
+          <mxGeometry width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-58" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-56">
+          <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-59" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-56">
+          <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-60" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="190" y="1745" width="340" height="343" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-61" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-60">
+          <mxGeometry width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-62" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-60">
+          <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-63" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-60">
+          <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-64" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="190" y="1829" width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-65" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-64">
+          <mxGeometry width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-66" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-64">
+          <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-67" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-64">
+          <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-68" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="190" y="1915" width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-69" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-68">
+          <mxGeometry width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-70" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-68">
+          <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-71" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-68">
+          <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-72" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="190" y="1995" width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-73" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-72">
+          <mxGeometry width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-74" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-72">
+          <mxGeometry x="10" y="10" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-75" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-72">
+          <mxGeometry x="310" y="16.669999999999845" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-80" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" vertex="1" parent="1">
+          <mxGeometry x="170" y="1425" width="380" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-81" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="190" y="1447.5" width="35" height="35" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-82" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="190" y="1505" width="340" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-83" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="204" y="1523" width="20" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-84" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-83">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="30" as="sourcePoint" />
+            <mxPoint x="10" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-85" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-83">
+          <mxGeometry width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-86" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+          <mxGeometry x="490" y="1520" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-87" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;align=left;" vertex="1" parent="1">
+          <mxGeometry x="236" y="1506" width="244" height="58" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-89" value="" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+          <mxGeometry x="1692.82" y="1255.94" width="371.87" height="670" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-90" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" vertex="1" parent="1">
+          <mxGeometry x="1548.75" y="1406" width="660" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-91" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" vertex="1" parent="1">
+          <mxGeometry x="1558.75" y="1428.5" width="35" height="35" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-92" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="2018.75" y="1431" width="20" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-93" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-92">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="30" as="sourcePoint" />
+            <mxPoint x="10" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-94" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-92">
+          <mxGeometry width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-133" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1578.75" y="1562" width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-134" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-133">
+          <mxGeometry width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-135" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-133">
+          <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-136" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-133">
+          <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-137" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1578.75" y="1632" width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-138" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-137">
+          <mxGeometry width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-139" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-137">
+          <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-140" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-137">
+          <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-141" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1578.75" y="1702" width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-142" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-141">
+          <mxGeometry width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-143" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-141">
+          <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-144" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-141">
+          <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-145" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1888.75" y="1562" width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-146" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-145">
+          <mxGeometry width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-147" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-145">
+          <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-148" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-145">
+          <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-149" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1888.75" y="1632" width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-150" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-149">
+          <mxGeometry width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-151" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-149">
+          <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-152" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-149">
+          <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-153" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1888.75" y="1702" width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-154" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=50;fontSize=24;flipV=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-153">
+          <mxGeometry width="290" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-155" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-153">
+          <mxGeometry x="10" y="15" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-156" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-153">
+          <mxGeometry x="260" y="18.329999999999927" width="20" height="26.67" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-163" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="1576.25" y="1484" width="605" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-164" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1593.75" y="1501" width="20" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-165" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-164">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="30" as="sourcePoint" />
+            <mxPoint x="10" y="10" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-166" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-164">
+          <mxGeometry width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-167" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
+          <mxGeometry x="2133.75" y="1501" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-168" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="1643.75" y="1486" width="470" height="58" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-169" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="80" y="140" width="450" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry width="450" height="980" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-6" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="15" y="840" width="420" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-7" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="15" y="909" width="420" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-8" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="15" y="10" width="420" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-10" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="15" y="110" as="sourcePoint" />
+            <mxPoint x="435" y="110" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-19" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="40" y="140" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-20" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="350" y="150" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-21" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="40" y="225" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-22" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="40" y="310" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-23" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="40" y="395" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-24" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="40" y="480" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-25" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="350" y="235" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-26" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="350" y="320" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-27" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="350" y="405" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-28" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry x="350" y="490" width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="RbmyN5pTn8aNILAV9D3_-37" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-169">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="15" y="819" as="sourcePoint" />
+            <mxPoint x="435" y="819" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-244" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="610" y="1425" width="250" height="665" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-171" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=light-dark(#FFFFFF,#FFFFFF);" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry width="250" height="665" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-172" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry x="8.340000000000032" y="573.5" width="233.33" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-173" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry x="8.340000000000032" y="615.5" width="233.33" height="29" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-174" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry x="8.33" y="10" width="233.33" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-175" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="8.333333333333371" y="80" as="sourcePoint" />
+            <mxPoint x="241.66666666666674" y="80" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-186" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="8.333333333333371" y="555.5" as="sourcePoint" />
+            <mxPoint x="241.66666666666674" y="555.5" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-187" value="" style="group" vertex="1" connectable="0" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry x="22.220000000000027" y="95" width="205.56" height="310" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-176" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-178" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry y="65.875" width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-179" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry y="131.75" width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-180" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry y="197.625" width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-181" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry y="263.5" width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-185" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry x="167.77999999999997" y="273.0615789473684" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-184" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry x="167.77999999999997" y="207.19368421052627" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-183" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry x="167.77999999999997" y="141.31578947368416" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-182" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-187">
+          <mxGeometry x="167.77999999999997" y="75.43789473684205" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-177" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-244">
+          <mxGeometry x="190" y="107" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-247" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=light-dark(#FFFFFF,#FFFFFF);" vertex="1" parent="1">
+          <mxGeometry x="1241" y="1400" width="250" height="390" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-250" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+          <mxGeometry x="1249.33" y="1410" width="233.33" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-251" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1249.3333333333335" y="1480" as="sourcePoint" />
+            <mxPoint x="1482.6666666666667" y="1480" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-253" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1263.22" y="1495" width="219.45000000000002" height="310" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-254" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-255" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry y="65.875" width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-256" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry y="131.75" width="205.56000000000006" height="46.5" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-261" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry x="167.77999999999997" y="141.31578947368416" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-262" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry x="167.77999999999997" y="75.43789473684205" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-248" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry x="-13.879999999999995" y="213" width="233.33" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-249" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=16;spacing=10;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry x="-13.879999999999995" y="255" width="233.33" height="29" as="geometry" />
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-252" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-253">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-13.886666666666656" y="195" as="sourcePoint" />
+            <mxPoint x="219.44666666666672" y="195" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-263" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="1431" y="1507" width="27.37" height="27.36842105263158" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="2aM2A-6S-Wh7pI4XLxjm" name="詳細画面">
+    <mxGraphModel dx="2646" dy="1490" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="9eAIsCWrS4Yunl0qI4hi" name="comopnent">
+    <mxGraphModel dx="1323" dy="745" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="620" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="783" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="864" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1109" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1190" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="1027" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="946" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="701" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="100" y="540" width="607.5" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-10" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="120" y="550" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-10">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-12" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-10">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-13" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="630" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-13">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-15" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-13">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-16" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="711" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-16">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-18" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-16">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-19" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="793" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-19">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-21" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-19">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-22" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="874" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-22">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-24" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-22">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-25" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="956" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-25">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-27" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-25">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-28" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="1037" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-28">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-30" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-28">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-31" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="1119" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-31">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-33" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-31">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-34" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="118.75" y="1200" width="570" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-34">
+          <mxGeometry width="40" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="g_dIYOH2svpPy-2GZ2_I-36" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-34">
+          <mxGeometry x="540" width="30" height="40" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
   <diagram name="Page-1" id="c9db0220-8083-56f3-ca83-edcdcd058819">
-    <mxGraphModel dx="1408" dy="748" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1.5" pageWidth="826" pageHeight="1169" background="none" math="0" shadow="0">
+    <mxGraphModel dx="879" dy="745" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1.5" pageWidth="826" pageHeight="1169" background="none" math="0" shadow="0">
       <root>
         <mxCell id="0" style=";html=1;" />
         <mxCell id="1" style=";html=1;" parent="0" />
@@ -192,348 +981,6 @@
           <mxGeometry y="1" width="80" height="40" relative="1" as="geometry">
             <mxPoint x="100" y="-60" as="offset" />
           </mxGeometry>
-        </mxCell>
-      </root>
-    </mxGraphModel>
-  </diagram>
-  <diagram id="FU8lBgzXBYsJgkfCLfBr" name="検索画面">
-    <mxGraphModel dx="4410" dy="2483" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
-      <root>
-        <mxCell id="0" />
-        <mxCell id="1" parent="0" />
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="80" y="70" width="1920" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="80" y="140" width="1920" height="980" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-3" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="80" y="140" width="450" height="980" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-6" value="外観モードを変更" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="1">
-          <mxGeometry x="95" y="980" width="420" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-7" value="OSSライセンスを表示" style="rounded=1;whiteSpace=wrap;html=1;arcSize=50;strokeWidth=1;whiteSpace=wrap;align=center;verticalAlign=middle;spacingLeft=0;fontStyle=0;fontSize=32;spacing=10;" vertex="1" parent="1">
-          <mxGeometry x="95" y="1049" width="420" height="50" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-8" value="検索履歴" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
-          <mxGeometry x="95" y="150" width="420" height="100" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-10" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="95" y="250" as="sourcePoint" />
-            <mxPoint x="515" y="250" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-19" value="flutter" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="120" y="280" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-20" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="430" y="290" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-21" value="dart" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="120" y="365" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-22" value="jest" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="120" y="450" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-23" value="riverpod" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="120" y="535" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-24" value="freezed" style="rounded=0;whiteSpace=wrap;html=1;fontSize=28;align=left;spacingLeft=12;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="120" y="620" width="370" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-25" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="430" y="375" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-26" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="430" y="460" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-27" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="430" y="545" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-28" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="430" y="630" width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-30" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-          <mxGeometry x="530" y="140" width="1470" height="980" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-31" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=56;" vertex="1" parent="1">
-          <mxGeometry x="530" y="160" width="1470" height="80" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-32" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="962.5" y="250" width="605" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-38" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="980" y="267" width="20" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-35" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="3NQUQ22dUql_FlJT8KjB-38">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="20" y="30" as="sourcePoint" />
-            <mxPoint x="10" y="10" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-34" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;rotation=-90;strokeWidth=5;" vertex="1" parent="3NQUQ22dUql_FlJT8KjB-38">
-          <mxGeometry width="20" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-40" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
-          <mxGeometry x="1520" y="267" width="30" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-42" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="1030" y="252" width="470" height="58" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="410" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="573" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="654" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="899" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="980" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="817" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="736" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="491" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="960" y="330" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-10" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="980" y="340" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-12" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-13" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="420" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-15" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-16" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="501" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-18" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-19" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="583" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-21" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-22" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="664" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-24" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-25" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="746" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-27" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-28" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="827" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-30" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-31" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="909" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-33" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-34" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="990" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-36" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-37" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=2;" edge="1" parent="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="95" y="959" as="sourcePoint" />
-            <mxPoint x="515" y="959" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-44" value="" style="group;strokeWidth=3;" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="490" y="190" width="20" height="20" as="geometry" />
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-45" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=3;" edge="1" parent="RbmyN5pTn8aNILAV9D3_-44">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint y="20" as="sourcePoint" />
-            <mxPoint x="20" y="10" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="RbmyN5pTn8aNILAV9D3_-46" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=3;" edge="1" parent="RbmyN5pTn8aNILAV9D3_-44">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint as="sourcePoint" />
-            <mxPoint x="20" y="9.999999999999545" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-      </root>
-    </mxGraphModel>
-  </diagram>
-  <diagram id="2aM2A-6S-Wh7pI4XLxjm" name="詳細画面">
-    <mxGraphModel dx="2646" dy="1490" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
-      <root>
-        <mxCell id="0" />
-        <mxCell id="1" parent="0" />
-      </root>
-    </mxGraphModel>
-  </diagram>
-  <diagram id="9eAIsCWrS4Yunl0qI4hi" name="comopnent">
-    <mxGraphModel dx="1323" dy="745" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
-      <root>
-        <mxCell id="0" />
-        <mxCell id="1" parent="0" />
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="620" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="783" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="864" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="1109" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="1190" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="1027" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="946" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="100" y="701" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="100" y="540" width="607.5" height="60" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-10" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="120" y="550" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-10">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-12" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-10">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-13" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="630" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-13">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-15" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-13">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-16" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="711" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-16">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-18" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-16">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-19" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="793" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-19">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-21" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-19">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-22" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="874" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-22">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-24" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-22">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-25" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="956" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-25">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-27" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-25">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-28" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="1037" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-28">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-30" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-28">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-31" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="1119" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-31">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-33" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-31">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-34" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="118.75" y="1200" width="570" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-34">
-          <mxGeometry width="40" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="g_dIYOH2svpPy-2GZ2_I-36" value="" style="triangle;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="g_dIYOH2svpPy-2GZ2_I-34">
-          <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/docs/UIデザイン.drawio
+++ b/docs/UIデザイン.drawio
@@ -1,10 +1,10 @@
 <mxfile host="app.diagrams.net" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" version="27.0.9" pages="4">
   <diagram id="FU8lBgzXBYsJgkfCLfBr" name="検索画面">
-    <mxGraphModel dx="4395" dy="3725" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="9507" dy="5180" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="3NQUQ22dUql_FlJT8KjB-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ検索画面&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
           <mxGeometry x="80" y="90" width="1920" height="50" as="geometry" />
         </mxCell>
         <mxCell id="3NQUQ22dUql_FlJT8KjB-2" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
@@ -13,14 +13,11 @@
         <mxCell id="3NQUQ22dUql_FlJT8KjB-30" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
           <mxGeometry x="2230" y="140" width="1920" height="980" as="geometry" />
         </mxCell>
-        <mxCell id="3NQUQ22dUql_FlJT8KjB-31" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=56;" vertex="1" parent="1">
-          <mxGeometry x="530" y="190" width="1470" height="80" as="geometry" />
-        </mxCell>
         <mxCell id="3NQUQ22dUql_FlJT8KjB-32" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="962.5" y="280" width="605" height="60" as="geometry" />
+          <mxGeometry x="952.5" y="170" width="605" height="60" as="geometry" />
         </mxCell>
         <mxCell id="3NQUQ22dUql_FlJT8KjB-38" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="980" y="297" width="20" height="30" as="geometry" />
+          <mxGeometry x="970" y="187" width="20" height="30" as="geometry" />
         </mxCell>
         <mxCell id="3NQUQ22dUql_FlJT8KjB-35" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="3NQUQ22dUql_FlJT8KjB-38">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
@@ -32,40 +29,40 @@
           <mxGeometry width="20" height="20" as="geometry" />
         </mxCell>
         <mxCell id="3NQUQ22dUql_FlJT8KjB-40" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
-          <mxGeometry x="1520" y="297" width="30" height="30" as="geometry" />
+          <mxGeometry x="1510" y="187" width="30" height="30" as="geometry" />
         </mxCell>
         <mxCell id="3NQUQ22dUql_FlJT8KjB-42" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="1030" y="282" width="470" height="58" as="geometry" />
+          <mxGeometry x="1020" y="172" width="470" height="58" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-1" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="440" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="330" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-2" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="603" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="493" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-3" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="684" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="574" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-4" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="929" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="819" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-5" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="1010" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="900" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-6" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="847" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="737" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-7" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="766" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="656" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-8" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="960" y="521" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="411" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-9" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="960" y="360" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="950" y="250" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-10" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="980" y="370" width="570" height="40" as="geometry" />
+          <mxGeometry x="970" y="260" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-11" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-10">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -74,7 +71,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-13" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="450" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="340" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-14" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-13">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -83,7 +80,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-16" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="531" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="421" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-16">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -92,7 +89,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-19" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="613" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="503" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-20" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-19">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -101,7 +98,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-22" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="694" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="584" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-23" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-22">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -110,7 +107,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-25" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="776" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="666" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-25">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -119,7 +116,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-28" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="857" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="747" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-28">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -128,7 +125,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-31" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="939" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="829" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-32" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-31">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -137,7 +134,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-34" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="978.75" y="1020" width="570" height="40" as="geometry" />
+          <mxGeometry x="968.75" y="910" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="RbmyN5pTn8aNILAV9D3_-35" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -145,20 +142,17 @@
         <mxCell id="RbmyN5pTn8aNILAV9D3_-36" value="" style="triangle;whiteSpace=wrap;html=1;" vertex="1" parent="RbmyN5pTn8aNILAV9D3_-34">
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxCell id="LQzH_NDQMfFLRa0uXr-V-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ検索画面&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
           <mxGeometry x="2230" y="90" width="1920" height="50" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-2" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=52;strokeWidth=0;" vertex="1" parent="1">
           <mxGeometry x="2260" y="180" width="50" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="LQzH_NDQMfFLRa0uXr-V-4" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=56;" vertex="1" parent="1">
-          <mxGeometry x="2455" y="180" width="1470" height="80" as="geometry" />
-        </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-5" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="2887.5" y="270" width="605" height="60" as="geometry" />
+          <mxGeometry x="2888.75" y="170" width="605" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-6" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="287" width="20" height="30" as="geometry" />
+          <mxGeometry x="2906.25" y="187" width="20" height="30" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-7" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-6">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
@@ -170,40 +164,40 @@
           <mxGeometry width="20" height="20" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-9" value="" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=mxgraph.flowchart.or;strokeWidth=4;" vertex="1" parent="1">
-          <mxGeometry x="3445" y="287" width="30" height="30" as="geometry" />
+          <mxGeometry x="3446.25" y="187" width="30" height="30" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-10" value="Search Textfield" style="rounded=0;whiteSpace=wrap;html=1;strokeWidth=0;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="2955" y="272" width="470" height="58" as="geometry" />
+          <mxGeometry x="2956.25" y="172" width="470" height="58" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-11" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="430" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="330" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-12" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="593" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="493" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-13" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="674" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="574" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-14" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="919" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="819" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-15" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="1000" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="900" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-16" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="837" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="737" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-17" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="756" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="656" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-18" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="511" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="411" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-19" value="&lt;font style=&quot;font-size: 28px;&quot;&gt;flutter&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;align=left;spacingLeft=80;fontSize=24;" vertex="1" parent="1">
-          <mxGeometry x="2885" y="350" width="607.5" height="60" as="geometry" />
+          <mxGeometry x="2886.25" y="250" width="607.5" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-20" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2905" y="360" width="570" height="40" as="geometry" />
+          <mxGeometry x="2906.25" y="260" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-21" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-20">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -212,7 +206,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-23" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="440" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="340" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-24" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-23">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -221,7 +215,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-26" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="521" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="421" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-27" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-26">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -230,7 +224,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-29" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="603" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="503" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-30" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-29">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -239,7 +233,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-32" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="684" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="584" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-33" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-32">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -248,7 +242,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-35" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="766" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="666" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-36" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-35">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -257,7 +251,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-38" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="847" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="747" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-39" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-38">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -266,7 +260,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-41" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="929" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="829" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-42" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-41">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -275,7 +269,7 @@
           <mxGeometry x="540" width="30" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-44" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2903.75" y="1010" width="570" height="40" as="geometry" />
+          <mxGeometry x="2905" y="910" width="570" height="40" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-45" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="LQzH_NDQMfFLRa0uXr-V-44">
           <mxGeometry width="40" height="40" as="geometry" />
@@ -389,13 +383,13 @@
           <mxGeometry x="1692.82" y="1255.94" width="371.87" height="670" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-90" value="リポジトリ検索画面" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=28;" vertex="1" parent="1">
-          <mxGeometry x="1548.75" y="1406" width="660" height="80" as="geometry" />
+          <mxGeometry x="1548.75" y="1406" width="660" height="60" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-91" value="≡" style="ellipse;whiteSpace=wrap;html=1;fontSize=32;strokeWidth=0;align=center;verticalAlign=middle;" vertex="1" parent="1">
-          <mxGeometry x="1558.75" y="1428.5" width="35" height="35" as="geometry" />
+          <mxGeometry x="1553.75" y="1418.5" width="35" height="35" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-92" value="" style="group" vertex="1" connectable="0" parent="1">
-          <mxGeometry x="2018.75" y="1431" width="20" height="30" as="geometry" />
+          <mxGeometry x="2018.75" y="1423" width="20" height="30" as="geometry" />
         </mxCell>
         <mxCell id="LQzH_NDQMfFLRa0uXr-V-93" value="" style="endArrow=none;html=1;rounded=0;strokeWidth=5;" edge="1" parent="LQzH_NDQMfFLRa0uXr-V-92">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
@@ -665,10 +659,172 @@
     </mxGraphModel>
   </diagram>
   <diagram id="2aM2A-6S-Wh7pI4XLxjm" name="詳細画面">
-    <mxGraphModel dx="2646" dy="1490" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="4753" dy="3759" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
+        <mxCell id="wAwD6aCW4f1jpx36XDWf-1" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="44" y="120" width="370" height="660" as="geometry" />
+        </mxCell>
+        <mxCell id="wAwD6aCW4f1jpx36XDWf-2" value="" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+          <mxGeometry x="802.5" y="97.5" width="365" height="660" as="geometry" />
+        </mxCell>
+        <mxCell id="wAwD6aCW4f1jpx36XDWf-3" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="44" y="120" width="370" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="655" y="240" width="660" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-4" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+          <mxGeometry x="189" y="210" width="80" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-17" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+          <mxGeometry x="153.63" y="280" width="150.75" height="125" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-23" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="60" y="380.1" width="336" height="260" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-18" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+          <mxGeometry y="55" width="336" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-19" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+          <mxGeometry y="110.19230769230768" width="336" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-20" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+          <mxGeometry y="165.38461538461536" width="336" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-21" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+          <mxGeometry y="220.5769230769231" width="336" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-22" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="duIHhKJAwggp7_61a4r5-23">
+          <mxGeometry width="336" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-26" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;" vertex="1" parent="1">
+          <mxGeometry x="670" y="254.67999999999995" width="24" height="30.64" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-27" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;" vertex="1" parent="1">
+          <mxGeometry x="60" y="134.67999999999995" width="24" height="30.64" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-12" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="60" y="720" width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-13" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-12">
+          <mxGeometry width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-14" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-12">
+          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-15" value="" style="group;flipH=1;" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="360" y="720" width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-16" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-15">
+          <mxGeometry width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-17" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;flipH=1;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-15">
+          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
+        </mxCell>
+        <mxCell id="C9AApOpk92xFXuM4X5s--1" value="&lt;span style=&quot;font-size: 28px;&quot;&gt;リポジトリ情報&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="40" y="-1010" width="1920" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="C9AApOpk92xFXuM4X5s--109" value="" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="40" y="-960" width="1920" height="950" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-16" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="668.75" y="-890" width="632.5" height="277.69000000000005" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-17" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-16">
+          <mxGeometry x="75.38" width="80" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-18" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-16">
+          <mxGeometry x="40" y="110.19" width="150.75" height="125" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-19" value="" style="group" vertex="1" connectable="0" parent="H9VjxzaiKczBng6LxmAf-16">
+          <mxGeometry x="230" width="340" height="260" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-20" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+          <mxGeometry y="55" width="340" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-21" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+          <mxGeometry y="110.19230769230768" width="340" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-22" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+          <mxGeometry y="165.38461538461536" width="340" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-23" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+          <mxGeometry y="220.5769230769231" width="340" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-24" value="" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-19">
+          <mxGeometry width="340" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-25" value="" style="group" vertex="1" connectable="0" parent="H9VjxzaiKczBng6LxmAf-16">
+          <mxGeometry y="235.19000000000005" width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-26" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-25">
+          <mxGeometry width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-27" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-25">
+          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-28" value="" style="group;flipH=1;" vertex="1" connectable="0" parent="H9VjxzaiKczBng6LxmAf-16">
+          <mxGeometry x="590" y="235" width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-29" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-28">
+          <mxGeometry width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="H9VjxzaiKczBng6LxmAf-30" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;flipH=1;" vertex="1" parent="H9VjxzaiKczBng6LxmAf-28">
+          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-3" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+          <mxGeometry x="785.38" y="325" width="80" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-5" value="AppName" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=32;" vertex="1" parent="1">
+          <mxGeometry x="750" y="435.19" width="150.75" height="125" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-6" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="670" y="560.19" width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-7" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-6">
+          <mxGeometry width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-8" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-6">
+          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-9" value="" style="group;flipH=1;" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1260" y="560" width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-10" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-9">
+          <mxGeometry width="42.5" height="42.5" as="geometry" />
+        </mxCell>
+        <mxCell id="P5SM2VEQe3d-N8lNLVMV-11" value="" style="html=1;shadow=0;dashed=0;align=center;verticalAlign=middle;shape=mxgraph.arrows2.arrow;dy=0;dx=30;notch=30;rotation=-180;strokeWidth=3;flipH=1;" vertex="1" parent="P5SM2VEQe3d-N8lNLVMV-9">
+          <mxGeometry x="14.25" y="12.309999999999945" width="14" height="17.87" as="geometry" />
+        </mxCell>
+        <mxCell id="4C3NyFkav0wo-2EBLAcl-1" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="940" y="325" width="280" height="260" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-6" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+          <mxGeometry y="55" width="280" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-12" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+          <mxGeometry y="110.19230769230768" width="280" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-13" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+          <mxGeometry y="165.38461538461536" width="280" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-14" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+          <mxGeometry y="220.5769230769231" width="280" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="duIHhKJAwggp7_61a4r5-16" value="" style="rounded=1;whiteSpace=wrap;html=1;container=0;" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-1">
+          <mxGeometry width="280" height="39.42307692307692" as="geometry" />
+        </mxCell>
+        <mxCell id="4C3NyFkav0wo-2EBLAcl-2" value="a" style="endArrow=classic;html=1;rounded=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=12;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="970" y="298.31" as="sourcePoint" />
+            <mxPoint x="970" y="-584" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4C3NyFkav0wo-2EBLAcl-3" value="同じウィジェット" style="edgeLabel;resizable=0;html=1;;align=center;verticalAlign=middle;fontSize=72;" connectable="0" vertex="1" parent="4C3NyFkav0wo-2EBLAcl-2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
       </root>
     </mxGraphModel>
   </diagram>

--- a/lib/static/number_data.dart
+++ b/lib/static/number_data.dart
@@ -1,3 +1,8 @@
 class NumberData {
   static const horizontalLayoutThreshold = 600.0;
+  static const paddingSmall = 8.0;
+  static const paddingMedium = 16.0;
+  static const paddingLarge = 24.0;
+  static const double horizontalLayoutThresholdWithoutPadding =
+      horizontalLayoutThreshold - paddingLarge * 2;
 }

--- a/lib/static/number_data.dart
+++ b/lib/static/number_data.dart
@@ -1,0 +1,3 @@
+class NumberData {
+  static const textFieldConstraintWidth = 600.0;
+}

--- a/lib/static/number_data.dart
+++ b/lib/static/number_data.dart
@@ -1,3 +1,3 @@
 class NumberData {
-  static const textFieldConstraintWidth = 600.0;
+  static const horizontalLayoutThreshold = 600.0;
 }

--- a/lib/view/page/repository_search_page.dart
+++ b/lib/view/page/repository_search_page.dart
@@ -38,7 +38,7 @@ class _SearchPageState extends ConsumerState<RepositorySearchPage> {
             children: [
               ConstrainedBox(
                 constraints: const BoxConstraints(
-                  maxWidth: NumberData.textFieldConstraintWidth,
+                  maxWidth: NumberData.horizontalLayoutThreshold,
                 ),
                 child: SearchTextField(
                   controller: controller,

--- a/lib/view/page/repository_search_page.dart
+++ b/lib/view/page/repository_search_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/git_hub_search_query.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/custom_drawer.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/search_result_list_view.dart';
@@ -35,27 +36,32 @@ class _SearchPageState extends ConsumerState<RepositorySearchPage> {
         body: Center(
           child: Column(
             children: [
-              SearchTextField(
-                controller: controller,
-                onChanged: (value) {
-                  ref
-                      .read(gitHubSearchQueryNotifierProvider.notifier)
-                      .setQuery(q: value);
-                },
-                onSubmitted: (value) {
-                  ref
-                      .read(gitHubSearchQueryNotifierProvider.notifier)
-                      .setQuery(q: value);
-                },
-                onCancelButtonPressed: () {
-                  setState(controller.clear);
-                  ref
-                      .read(gitHubSearchQueryNotifierProvider.notifier)
-                      .setQuery(q: '');
-                },
-                labelText:
-                    AppLocalizations.of(context)?.searchRepositories ??
-                    WordingData.searchRepositories,
+              ConstrainedBox(
+                constraints: const BoxConstraints(
+                  maxWidth: NumberData.textFieldConstraintWidth,
+                ),
+                child: SearchTextField(
+                  controller: controller,
+                  onChanged: (value) {
+                    ref
+                        .read(gitHubSearchQueryNotifierProvider.notifier)
+                        .setQuery(q: value);
+                  },
+                  onSubmitted: (value) {
+                    ref
+                        .read(gitHubSearchQueryNotifierProvider.notifier)
+                        .setQuery(q: value);
+                  },
+                  onCancelButtonPressed: () {
+                    setState(controller.clear);
+                    ref
+                        .read(gitHubSearchQueryNotifierProvider.notifier)
+                        .setQuery(q: '');
+                  },
+                  labelText:
+                      AppLocalizations.of(context)?.searchRepositories ??
+                      WordingData.searchRepositories,
+                ),
               ),
               const SizedBox(height: 8),
               const Expanded(

--- a/lib/view/widget/owner_icon.dart
+++ b/lib/view/widget/owner_icon.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+
+/// リポジトリのオーナーのアバター画像を表示するウィジェット
+///
+/// オーナーが設定されていない場合や画像の読み込みに失敗した場合はデフォルトのアイコンを表示
+/// 読み込み中はCircularProgressIndicatorを表示
+class OwnerIcon extends StatelessWidget {
+  const OwnerIcon({required this.repository, this.diameter, super.key});
+
+  /// オーナーのアバター画像の直径
+  final double? diameter;
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = repository.owner?.avatarUrl;
+
+    if (avatarUrl == null || avatarUrl.isEmpty) {
+      return _buildDefaultAvatar(context);
+    }
+
+    return _DecoratedAvatarCircle(
+      diameter: diameter,
+      child: ClipOval(
+        child: Image.network(
+          avatarUrl,
+          width: diameter,
+          height: diameter,
+          fit: BoxFit.cover,
+          errorBuilder: _buildDefaultAvatar,
+          loadingBuilder: _buildImageLoadingIndicator,
+        ),
+      ),
+    );
+  }
+
+  /// デフォルトのアバターを構築する
+  ///
+  /// Ownerがセットされてなかったりエラー時に表示されるウィジェット
+  Widget _buildDefaultAvatar(
+    BuildContext context, [
+    Object? error,
+    StackTrace? stackTrace,
+  ]) {
+    return _DecoratedAvatarCircle(
+      diameter: diameter,
+      child: Icon(
+        Icons.person,
+        size: diameter,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+
+  /// ネットワーク画像のローディング表示を構築する
+  ///
+  /// 読み込み中はCircularProgressIndicatorを表示し、完了時は子ウィジェットをそのまま表示
+  Widget _buildImageLoadingIndicator(
+    BuildContext context,
+    Widget child,
+    ImageChunkEvent? loadingProgress,
+  ) {
+    // 読み込み完了時は子ウィジェットをそのまま表示
+    if (loadingProgress == null) {
+      return child;
+    }
+
+    // 読み込み進捗を計算
+    final progress = _calculateLoadingProgress(loadingProgress);
+
+    return _DecoratedAvatarCircle(
+      diameter: diameter,
+      child: CircularProgressIndicator(
+        value: progress,
+        strokeWidth: 2,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        valueColor: AlwaysStoppedAnimation<Color>(
+          Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  /// 読み込み進捗を計算する（0.0〜1.0の範囲）
+  double? _calculateLoadingProgress(ImageChunkEvent loadingProgress) {
+    final expectedTotalBytes = loadingProgress.expectedTotalBytes;
+    if (expectedTotalBytes == null) {
+      return null; // 不定進捗
+    }
+
+    return loadingProgress.cumulativeBytesLoaded / expectedTotalBytes;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+    properties.add(DoubleProperty('diameter', diameter));
+  }
+}
+
+/// 飾りが施されたCircleAvatarウィジェット
+///
+/// 影と背景色を持つ円形のアバターを表示
+class _DecoratedAvatarCircle extends StatelessWidget {
+  const _DecoratedAvatarCircle({required this.child, this.diameter});
+
+  final double? diameter;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(
+              context,
+            ).colorScheme.shadow.withAlpha((255 * 0.3).round()),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('diameter', diameter));
+  }
+}

--- a/lib/view/widget/repository_card_ui_builder.dart
+++ b/lib/view/widget/repository_card_ui_builder.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_layout_strategy.dart';
+
+/// Repository Details Card のUI構築を担当するクラス
+///
+/// カードの見た目と構造を管理する専用クラス
+/// UI構築の責任を分離し、メインのStateクラスをシンプルに保つ
+class RepositoryCardUIBuilder {
+  const RepositoryCardUIBuilder({
+    required this.repository,
+    required this.isHeroAnimationCompleted,
+    required this.isHeroAnimationInProgress,
+  });
+
+  final Repository repository;
+  final bool isHeroAnimationCompleted;
+  final bool isHeroAnimationInProgress;
+
+  /// カードコンテンツの構築
+  ///
+  /// リポジトリ情報を表示するカードウィジェットを作成する
+  ///
+  /// 【構成要素】
+  /// - SizedBox.expand: 利用可能な全領域を使用
+  /// - Card: マテリアルデザインのカード
+  /// - 内容: リポジトリ情報とレイアウト戦略による表示切替
+  Widget buildCardContent(BuildContext context) {
+    return SizedBox.expand(
+      child: Card(
+        margin: const EdgeInsets.all(8),
+        shape: _buildCardShape(),
+        color: _determineCardColor(context),
+        child: _buildCardBody(),
+      ),
+    );
+  }
+
+  /// アニメーション時のDecoration構築
+  ///
+  /// Heroアニメーション中に表示される装飾効果を作成する
+  ///
+  /// 【効果】
+  /// - ボーダー: 角丸16pxの四角形
+  /// - 影: アニメーション進行に応じて濃さ・ぼかし・広がりが変化
+  /// - 色: 黒色ベース、透明度は animation.value * 0.3
+  BoxDecoration buildAnimationDecoration(Animation<double> animation) {
+    return BoxDecoration(
+      borderRadius: BorderRadius.circular(16),
+      boxShadow: [
+        BoxShadow(
+          color: Colors.black.withValues(alpha: 0.3 * animation.value),
+          blurRadius: 10 * animation.value,
+          spreadRadius: 2 * animation.value,
+        ),
+      ],
+    );
+  }
+
+  /// カードの形状を決定
+  ///
+  /// 角丸16pxの四角形カードを作成する
+  /// 統一されたデザインを保つため、角丸値は固定
+  RoundedRectangleBorder _buildCardShape() {
+    return RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(16),
+    );
+  }
+
+  /// アニメーション状態に応じたカード色を決定
+  ///
+  /// アニメーションの進行状況によってカードの透明度を調整する
+  ///
+  /// 【色の変化】
+  /// - 完了時: テーマのカード色をそのまま使用
+  /// - 進行中: テーマのカード色を80%の透明度で表示
+  Color _determineCardColor(BuildContext context) {
+    final cardColor = Theme.of(context).cardColor;
+
+    return isHeroAnimationCompleted
+        ? cardColor
+        : cardColor.withAlpha((255 * 0.8).round());
+  }
+
+  /// カード本体の構築
+  ///
+  /// カード内に表示するコンテンツを作成する
+  ///
+  /// 【構成】
+  /// - Padding: 左右18px、上下18pxの余白
+  /// - SingleChildScrollView: 内容が溢れた場合のスクロール対応
+  /// - _RepositoryInfo: 実際のリポジトリ情報表示ウィジェット
+  Widget _buildCardBody() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+      child: SingleChildScrollView(
+        child: _RepositoryInfo(
+          repository: repository,
+          isHeroAnimationCompleted: isHeroAnimationCompleted,
+          isHeroAnimationInProgress: isHeroAnimationInProgress,
+        ),
+      ),
+    );
+  }
+}
+
+/// リポジトリ情報を表示するウィジェット
+///
+/// 画面サイズとアニメーション状態に応じてレイアウト戦略を切り替える
+///
+/// 【レイアウト戦略】
+/// - アニメーション中: MediaQueryで判定（安定性重視）
+/// - アニメーション完了後: LayoutBuilderで判定（精度重視）
+///
+/// 【表示パターン】
+/// - 横レイアウト: タイトル上部、左にアイコン、右に詳細情報
+/// - 縦レイアウト: アイコン上部、その下にタイトルと詳細情報
+class _RepositoryInfo extends StatelessWidget {
+  const _RepositoryInfo({
+    required this.repository,
+    required this.isHeroAnimationCompleted,
+    required this.isHeroAnimationInProgress,
+  });
+
+  final Repository repository;
+  final bool isHeroAnimationCompleted;
+  final bool isHeroAnimationInProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    // アニメーション状態に基づいてレイアウト戦略ウィジェットを選択
+    // StatelessWidgetベースのファクトリーパターンで効率的なウィジェットツリーを構築
+    return LayoutStrategyFactory.createStrategy(
+      isAnimationInProgress: isHeroAnimationInProgress,
+      isAnimationCompleted: isHeroAnimationCompleted,
+      repository: repository,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'isHeroAnimationCompleted',
+        isHeroAnimationCompleted,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'isHeroAnimationInProgress',
+        isHeroAnimationInProgress,
+      ),
+    );
+  }
+}

--- a/lib/view/widget/repository_details_card.dart
+++ b/lib/view/widget/repository_details_card.dart
@@ -1,17 +1,138 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
-import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
-import 'package:yumemi_flutter_engineer_codecheck/view/widget/owner_icon.dart';
-import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_info_view.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_card_ui_builder.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_hero_animation_builder.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_hero_animation_monitor.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_hero_animation_state.dart';
 
 /// GitHubリポジトリ詳細表示ウィジェット
 ///
 /// リポジトリの情報をカード形式で表示
 /// レイアウトは画面幅に応じて縦横切り替え
-class RepositoryDetailsCard extends StatelessWidget {
+class RepositoryDetailsCard extends StatefulWidget {
   const RepositoryDetailsCard({required this.repository, super.key});
   final Repository repository;
+
+  @override
+  State<RepositoryDetailsCard> createState() => _RepositoryDetailsCardState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+class _RepositoryDetailsCardState extends State<RepositoryDetailsCard>
+    with TickerProviderStateMixin {
+  late AnimationController _heroAnimationController;
+  late HeroAnimationState _animationState;
+  late HeroAnimationMonitor _animationMonitor;
+
+  // Lazy initialization のためのキャッシュ
+  RepositoryCardUIBuilder? _cachedUIBuilder;
+  RepositoryHeroAnimationBuilder? _cachedHeroAnimationBuilder;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeComponents();
+    _setupAnimationController();
+  }
+
+  /// 全コンポーネントの初期化
+  ///
+  /// アニメーション状態管理とモニタリングクラスを初期化する
+  /// 初期化処理を一箇所にまとめることで保守性を向上
+  void _initializeComponents() {
+    _animationState = HeroAnimationState();
+    _animationMonitor = HeroAnimationMonitor(_animationState);
+  }
+
+  /// アニメーションコントローラーのセットアップ
+  ///
+  /// Heroアニメーションのコントローラーを作成し、状態監視を開始する
+  /// セットアップロジックを分離することで、責任を明確化
+  void _setupAnimationController() {
+    _heroAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 500),
+      vsync: this,
+    );
+
+    _animationMonitor.monitorControllerAnimation(_heroAnimationController);
+
+    // 状態変化の監視
+    _animationState.addListener(_onAnimationStateChanged);
+  }
+
+  /// アニメーション状態変化時のコールバック
+  ///
+  /// アニメーション状態が変わった時に呼ばれる処理
+  /// build中の呼び出しによるエラーを防ぐため、フレーム後に実行を延期している
+  ///
+  /// 【注意】setState()をbuild中に呼ぶとエラーになるため、
+  /// addPostFrameCallback()を使用して安全なタイミングで実行
+  void _onAnimationStateChanged() {
+    if (mounted) {
+      // build中の呼び出しを避けるため、フレーム後に実行を延期
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            // キャッシュをクリアして再生成を促す
+            _cachedUIBuilder = null;
+            _cachedHeroAnimationBuilder = null;
+          });
+        }
+      });
+    }
+  }
+
+  /// UIBuilderの遅延生成
+  ///
+  /// 必要になった時点でUIBuilderインスタンスを作成する
+  /// キャッシュ機能により、同じ状態なら再利用してパフォーマンスを向上
+  ///
+  /// 【利点】
+  /// - メモリ使用量の最適化
+  /// - 不要な再生成を防止
+  /// - アニメーション状態に応じた適切なUIBuilder生成
+  RepositoryCardUIBuilder get _uiBuilder {
+    _cachedUIBuilder ??= RepositoryCardUIBuilder(
+      repository: widget.repository,
+      isHeroAnimationCompleted: _animationState.isCompleted,
+      isHeroAnimationInProgress: _animationState.isInProgress,
+    );
+    return _cachedUIBuilder!;
+  }
+
+  /// HeroAnimationBuilderの遅延生成
+  ///
+  /// 必要になった時点でHeroAnimationBuilderインスタンスを作成する
+  /// UIBuilderに依存するため、UIBuilderが先に生成される
+  ///
+  /// 【設計上の注意】
+  /// - uiBuilderプロパティを通じてUIBuilderのgetterを呼び出す
+  /// - これにより依存関係が明確になり、適切な順序で初期化される
+  RepositoryHeroAnimationBuilder get _heroAnimationBuilder {
+    _cachedHeroAnimationBuilder ??= RepositoryHeroAnimationBuilder(
+      uiBuilder: _uiBuilder,
+      animationMonitor: _animationMonitor,
+    );
+    return _cachedHeroAnimationBuilder!;
+  }
+
+  /// アニメーション完了状態の取得
+  ///
+  /// 外部から直接 _animationState にアクセスするのを防ぐ
+  /// アニメーションが完了しているかどうかを安全に取得できる
+  bool get isHeroAnimationCompleted => _animationState.isCompleted;
+
+  /// アニメーション進行状態の取得
+  ///
+  /// 外部から直接 _animationState にアクセスするのを防ぐ
+  /// アニメーションが進行中かどうかを安全に取得できる
+  bool get isHeroAnimationInProgress => _animationState.isInProgress;
 
   @override
   Widget build(BuildContext context) {
@@ -20,150 +141,49 @@ class RepositoryDetailsCard extends StatelessWidget {
         // ヒーローアニメーションを使用してリポジトリの詳細を表示
         // 検索画面のリストビューと同一のタグを使用することで実現している
         transitionOnUserGestures: true,
-        tag: 'repository-${repository.name}',
-        child: SizedBox.expand(
-          child: Card(
-            margin: const EdgeInsets.all(8),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
-              child: SingleChildScrollView(
-                child: _RepositoryInfo(repository: repository),
-              ),
-            ),
-          ),
+        tag: 'repository-${widget.repository.name}',
+        // Hero アニメーションの詳細制御
+        flightShuttleBuilder: _heroAnimationBuilder.buildFlightShuttle,
+        child: AnimatedBuilder(
+          animation: _animationState,
+          builder: (context, child) {
+            // キャッシュされたUIBuilderを使用（状態変化時は自動で再作成される）
+            return _uiBuilder.buildCardContent(context);
+          },
         ),
       ),
     );
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  void dispose() {
+    _disposeAnimationComponents();
+    super.dispose();
   }
-}
 
-/// リポジトリ情報を表示するウィジェット
-///
-/// 画面幅に応じて縦横のレイアウトを切り替える
-/// - 横レイアウト: タイトルとオーナーアイコンを横並び
-/// - 縦レイアウト: タイトルの下にオーナーアイコン
-class _RepositoryInfo extends StatelessWidget {
-  const _RepositoryInfo({required this.repository});
-  final Repository repository;
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth >= NumberData.horizontalLayoutThreshold) {
-          return _RepositoryInfoHorizontalLayout(repository: repository);
-        } else {
-          return _RepositoryInfoVerticalLayout(repository: repository);
-        }
-      },
-    );
+  /// アニメーション関連コンポーネントの破棄
+  ///
+  /// ウィジェットが破棄される際にリソースを適切に解放する
+  /// メモリリークを防ぐため、AnimationControllerとStateを破棄
+  void _disposeAnimationComponents() {
+    _heroAnimationController.dispose();
+    _animationState.dispose();
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// リポジトリ情報の縦方向に長いレイアウト用のウィジェット
-class _RepositoryInfoVerticalLayout extends StatelessWidget {
-  const _RepositoryInfoVerticalLayout({
-    required this.repository,
-  });
-
-  final Repository repository;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        OwnerIcon(repository: repository, diameter: 80),
-        const SizedBox(height: 12),
-        _RepositoryTitle(repository: repository),
-        const SizedBox(height: 16),
-        RepositoryDetailsInfoView(repository: repository),
-      ],
-    );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// リポジトリ情報の横方向に長いレイアウト用のウィジェット
-class _RepositoryInfoHorizontalLayout extends StatelessWidget {
-  const _RepositoryInfoHorizontalLayout({
-    required this.repository,
-  });
-
-  final Repository repository;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        _RepositoryTitle(repository: repository),
-        const SizedBox(height: 16),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            OwnerIcon(repository: repository, diameter: 80),
-            const SizedBox(width: 24),
-            Expanded(
-              child: RepositoryDetailsInfoView(repository: repository),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// リポジトリのタイトルを表示するウィジェット
-///
-/// タイトルは太字で、最大2行まで表示
-/// オーバーフロー時は省略記号を表示
-/// テキストは中央揃え
-class _RepositoryTitle extends StatelessWidget {
-  const _RepositoryTitle({required this.repository});
-  final Repository repository;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Text(
-      repository.name,
-      style: theme.textTheme.headlineSmall?.copyWith(
-        fontWeight: FontWeight.bold,
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'isHeroAnimationCompleted',
+        isHeroAnimationCompleted,
       ),
-      overflow: TextOverflow.ellipsis,
-      maxLines: 2,
-      textAlign: TextAlign.center,
     );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'isHeroAnimationInProgress',
+        isHeroAnimationInProgress,
+      ),
+    );
   }
 }

--- a/lib/view/widget/repository_details_card.dart
+++ b/lib/view/widget/repository_details_card.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/owner_icon.dart';
 
 /// GitHubリポジトリ詳細表示ウィジェット
 ///
@@ -87,7 +88,7 @@ class _RepositoryInfoVerticalLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        _OwnerIcon(repository: repository),
+        OwnerIcon(repository: repository, diameter: 80),
         const SizedBox(height: 12),
         _RepositoryTitle(repository: repository),
         const SizedBox(height: 16),
@@ -120,7 +121,7 @@ class _RepositoryInfoHorizontalLayout extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _OwnerIcon(repository: repository),
+            OwnerIcon(repository: repository, diameter: 80),
             const SizedBox(width: 24),
             Expanded(
               child: _RepositoryDetailsInfoView(repository: repository),
@@ -135,130 +136,6 @@ class _RepositoryInfoHorizontalLayout extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// リポジトリのオーナーのアバター画像を表示するウィジェット
-///
-/// オーナーが設定されていない場合や画像の読み込みに失敗した場合はデフォルトのアイコンを表示
-/// 読み込み中はCircularProgressIndicatorを表示
-class _OwnerIcon extends StatelessWidget {
-  const _OwnerIcon({required this.repository});
-  final Repository repository;
-
-  @override
-  Widget build(BuildContext context) {
-    final avatarUrl = repository.owner?.avatarUrl;
-
-    if (avatarUrl == null || avatarUrl.isEmpty) {
-      return _buildDefaultAvatar(context);
-    }
-
-    return _DecoratedAvatarCircle(
-      child: ClipOval(
-        child: Image.network(
-          avatarUrl,
-          width: 80,
-          height: 80,
-          fit: BoxFit.cover,
-          errorBuilder: _buildDefaultAvatar,
-          loadingBuilder: _buildImageLoadingIndicator,
-        ),
-      ),
-    );
-  }
-
-  /// デフォルトのアバターを構築する
-  ///
-  /// Ownerがセットされてなかったりエラー時に表示されるウィジェット
-  Widget _buildDefaultAvatar(
-    BuildContext context, [
-    Object? error,
-    StackTrace? stackTrace,
-  ]) {
-    return _DecoratedAvatarCircle(
-      child: Icon(
-        Icons.person,
-        size: 40,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-    );
-  }
-
-  /// ネットワーク画像のローディング表示を構築する
-  ///
-  /// 読み込み中はCircularProgressIndicatorを表示し、完了時は子ウィジェットをそのまま表示
-  Widget _buildImageLoadingIndicator(
-    BuildContext context,
-    Widget child,
-    ImageChunkEvent? loadingProgress,
-  ) {
-    // 読み込み完了時は子ウィジェットをそのまま表示
-    if (loadingProgress == null) {
-      return child;
-    }
-
-    // 読み込み進捗を計算
-    final progress = _calculateLoadingProgress(loadingProgress);
-
-    return _DecoratedAvatarCircle(
-      child: CircularProgressIndicator(
-        value: progress,
-        strokeWidth: 2,
-        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-        valueColor: AlwaysStoppedAnimation<Color>(
-          Theme.of(context).colorScheme.primary,
-        ),
-      ),
-    );
-  }
-
-  /// 読み込み進捗を計算する（0.0〜1.0の範囲）
-  double? _calculateLoadingProgress(ImageChunkEvent loadingProgress) {
-    final expectedTotalBytes = loadingProgress.expectedTotalBytes;
-    if (expectedTotalBytes == null) {
-      return null; // 不定進捗
-    }
-
-    return loadingProgress.cumulativeBytesLoaded / expectedTotalBytes;
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// 飾りが施されたCircleAvatarウィジェット
-///
-/// 影と背景色を持つ円形のアバターを表示
-class _DecoratedAvatarCircle extends StatelessWidget {
-  const _DecoratedAvatarCircle({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Theme.of(
-              context,
-            ).colorScheme.shadow.withAlpha((255 * 0.3).round()),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: CircleAvatar(
-        radius: 40,
-        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-        child: child,
-      ),
-    );
   }
 }
 

--- a/lib/view/widget/repository_details_card.dart
+++ b/lib/view/widget/repository_details_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/owner_icon.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_info_view.dart';
 
@@ -58,7 +59,7 @@ class _RepositoryInfo extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        if (constraints.maxWidth >= 600) {
+        if (constraints.maxWidth >= NumberData.horizontalLayoutThreshold) {
           return _RepositoryInfoHorizontalLayout(repository: repository);
         } else {
           return _RepositoryInfoVerticalLayout(repository: repository);

--- a/lib/view/widget/repository_details_card.dart
+++ b/lib/view/widget/repository_details_card.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
-import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
-import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/owner_icon.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_info_view.dart';
 
 /// GitHubリポジトリ詳細表示ウィジェット
 ///
@@ -92,7 +90,7 @@ class _RepositoryInfoVerticalLayout extends StatelessWidget {
         const SizedBox(height: 12),
         _RepositoryTitle(repository: repository),
         const SizedBox(height: 16),
-        _RepositoryDetailsInfoView(repository: repository),
+        RepositoryDetailsInfoView(repository: repository),
       ],
     );
   }
@@ -124,7 +122,7 @@ class _RepositoryInfoHorizontalLayout extends StatelessWidget {
             OwnerIcon(repository: repository, diameter: 80),
             const SizedBox(width: 24),
             Expanded(
-              child: _RepositoryDetailsInfoView(repository: repository),
+              child: RepositoryDetailsInfoView(repository: repository),
             ),
           ],
         ),
@@ -136,137 +134,6 @@ class _RepositoryInfoHorizontalLayout extends StatelessWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// リポジトリの詳細情報を表示するウィジェット
-///
-/// リポジトリの言語、スター数、ウォッチャー数、フォーク数、オープンイシュー数を表示
-/// 情報はアイコンとラベル付きでカード形式で表示される
-class _RepositoryDetailsInfoView extends StatelessWidget {
-  const _RepositoryDetailsInfoView({required this.repository});
-
-  final Repository repository;
-
-  @override
-  Widget build(BuildContext context) {
-    return Wrap(
-      runSpacing: 8,
-      children:
-          _buildInfoItems(
-            context,
-            AppLocalizations.of(context),
-          ).map((item) => _InfoRow(item: item)).toList(),
-    );
-  }
-
-  /// リポジトリ情報項目のリストを構築
-  ///
-  /// 各項目はアイコン、ラベル、値を持つ
-  /// プロジェクト言語、スター数、ウォッチャー数、フォーク数、オープンイシュー数の順で表示
-  List<_InfoRowItem> _buildInfoItems(
-    BuildContext context,
-    AppLocalizations? l10n,
-  ) {
-    return [
-      _InfoRowItem(
-        icon: Icons.code,
-        label: l10n?.repoLanguage ?? WordingData.repoLanguage,
-        value: repository.language ?? WordingData.unknownLanguage,
-      ),
-      _InfoRowItem(
-        icon: Icons.star,
-        label: l10n?.repoStars ?? WordingData.repoStars,
-        value: _formatNumber(context, repository.stargazersCount),
-      ),
-      _InfoRowItem(
-        icon: Icons.visibility,
-        label: l10n?.repoWatchers ?? WordingData.repoWatchers,
-        value: _formatNumber(context, repository.watchersCount),
-      ),
-      _InfoRowItem(
-        icon: Icons.call_split,
-        label: l10n?.repoForks ?? WordingData.repoForks,
-        value: _formatNumber(context, repository.forksCount),
-      ),
-      _InfoRowItem(
-        icon: Icons.error_outline,
-        label: l10n?.repoIssues ?? WordingData.repoIssues,
-        value: _formatNumber(context, repository.openIssuesCount),
-      ),
-    ];
-  }
-
-  String _formatNumber(BuildContext context, int number) {
-    final localeString = Localizations.localeOf(context).toString();
-    return NumberFormat.compact(locale: localeString).format(number);
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Repository>('repository', repository));
-  }
-}
-
-/// リポジトリ情報項目のデータクラス
-class _InfoRowItem {
-  const _InfoRowItem({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
-
-  final IconData icon;
-  final String label;
-  final String value;
-}
-
-/// リポジトリ情報項目を表示するウィジェット
-///
-/// アイコン、ラベル、値を横並びで表示
-class _InfoRow extends StatelessWidget {
-  const _InfoRow({required this.item});
-
-  final _InfoRowItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card.filled(
-      margin: EdgeInsets.zero,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Row(
-          children: [
-            Icon(
-              item.icon,
-              size: 20,
-            ),
-            const SizedBox(width: 18),
-            Expanded(
-              child: Text(
-                item.label,
-                style: Theme.of(context).textTheme.bodyMedium,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            Text(
-              item.value,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<_InfoRowItem>('item', item));
   }
 }
 

--- a/lib/view/widget/repository_details_info_view.dart
+++ b/lib/view/widget/repository_details_info_view.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+
+/// リポジトリの詳細情報を表示するウィジェット
+///
+/// リポジトリの言語、スター数、ウォッチャー数、フォーク数、オープンイシュー数を表示
+/// 情報はアイコンとラベル付きでカード形式で表示される
+class RepositoryDetailsInfoView extends StatelessWidget {
+  const RepositoryDetailsInfoView({required this.repository, super.key});
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      runSpacing: 8,
+      children:
+          _buildInfoItems(
+            context,
+            AppLocalizations.of(context),
+          ).map((item) => _InfoRow(item: item)).toList(),
+    );
+  }
+
+  /// リポジトリ情報項目のリストを構築
+  ///
+  /// 各項目はアイコン、ラベル、値を持つ
+  /// プロジェクト言語、スター数、ウォッチャー数、フォーク数、オープンイシュー数の順で表示
+  List<_InfoRowItem> _buildInfoItems(
+    BuildContext context,
+    AppLocalizations? l10n,
+  ) {
+    return [
+      _InfoRowItem(
+        icon: Icons.code,
+        label: l10n?.repoLanguage ?? WordingData.repoLanguage,
+        value: repository.language ?? WordingData.unknownLanguage,
+      ),
+      _InfoRowItem(
+        icon: Icons.star,
+        label: l10n?.repoStars ?? WordingData.repoStars,
+        value: _formatNumber(context, repository.stargazersCount),
+      ),
+      _InfoRowItem(
+        icon: Icons.visibility,
+        label: l10n?.repoWatchers ?? WordingData.repoWatchers,
+        value: _formatNumber(context, repository.watchersCount),
+      ),
+      _InfoRowItem(
+        icon: Icons.call_split,
+        label: l10n?.repoForks ?? WordingData.repoForks,
+        value: _formatNumber(context, repository.forksCount),
+      ),
+      _InfoRowItem(
+        icon: Icons.error_outline,
+        label: l10n?.repoIssues ?? WordingData.repoIssues,
+        value: _formatNumber(context, repository.openIssuesCount),
+      ),
+    ];
+  }
+
+  String _formatNumber(BuildContext context, int number) {
+    final localeString = Localizations.localeOf(context).toString();
+    return NumberFormat.compact(locale: localeString).format(number);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリ情報項目のデータクラス
+class _InfoRowItem {
+  const _InfoRowItem({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+}
+
+/// リポジトリ情報項目を表示するウィジェット
+///
+/// アイコン、ラベル、値を横並びで表示
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.item});
+
+  final _InfoRowItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card.filled(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            Icon(
+              item.icon,
+              size: 20,
+            ),
+            const SizedBox(width: 18),
+            Expanded(
+              child: Text(
+                item.label,
+                style: Theme.of(context).textTheme.bodyMedium,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              item.value,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<_InfoRowItem>('item', item));
+  }
+}

--- a/lib/view/widget/repository_hero_animation_builder.dart
+++ b/lib/view/widget/repository_hero_animation_builder.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_card_ui_builder.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_hero_animation_monitor.dart';
+
+/// Hero Animation Flight Shuttle の構築を担当するクラス
+///
+/// Heroアニメーション中の表示効果を管理する専用クラス
+/// アニメーション構築の複雑なロジックを分離し、再利用可能にする
+class RepositoryHeroAnimationBuilder {
+  const RepositoryHeroAnimationBuilder({
+    required this.uiBuilder,
+    required this.animationMonitor,
+  });
+
+  final RepositoryCardUIBuilder uiBuilder;
+  final HeroAnimationMonitor animationMonitor;
+
+  /// Hero アニメーションのflightShuttleBuilderのコールバック
+  ///
+  /// 遷移前後のウィジェットを滑らかにブレンドするアニメーションを構築する
+  ///
+  /// 【Hero Animation の特徴】
+  /// - 遷移開始時: fromHero（遷移元）のウィジェットから開始
+  /// - 遷移途中: 両方のウィジェットをブレンド表示
+  /// - 遷移完了時: toHero（遷移先）のウィジェットに変化
+  ///
+  /// 【実装のポイント】
+  /// - アニメーション監視は build 処理後に遅延実行
+  /// - CrossFadeTransition で遷移前後のウィジェットを滑らかに切り替え
+  /// - Transform とDecorationで追加の視覚効果を演出
+  Widget buildFlightShuttle(
+    BuildContext flightContext,
+    Animation<double> animation,
+    HeroFlightDirection flightDirection,
+    BuildContext fromHeroContext,
+    BuildContext toHeroContext,
+  ) {
+    // アニメーション状態の監視を開始
+    animationMonitor.monitorFlightAnimation(animation, flightDirection);
+
+    // 遷移前後のウィジェットを取得
+    final fromHeroWidget = _extractWidgetFromContext(fromHeroContext);
+    final toHeroWidget = _extractWidgetFromContext(toHeroContext);
+
+    // カスタムHero Animation効果を適用
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) {
+        return _buildAnimatedTransition(
+          animation: animation,
+          fromWidget: fromHeroWidget,
+          toWidget: toHeroWidget,
+          direction: flightDirection,
+        );
+      },
+    );
+  }
+
+  /// コンテキストからウィジェットを抽出する
+  ///
+  /// HeroアニメーションのコンテキストからWidget情報を安全に取得する
+  /// コンテキストが無効な場合は空のContainerを返す
+  Widget _extractWidgetFromContext(BuildContext context) {
+    try {
+      final widget = context.widget;
+      return widget is Hero ? widget.child : widget;
+    } on Exception {
+      // コンテキストが無効な場合の安全な代替
+      return const SizedBox.shrink();
+    }
+  }
+
+  /// アニメーション遷移効果を構築する
+  ///
+  /// 標準的なHeroアニメーションのクロスフェード効果を実現する
+  ///
+  /// 【標準的なHero Animation】
+  /// - fromWidget と toWidget を同時に重ねて配置
+  /// - アニメーション進行に応じて透明度を反転
+  /// - fromWidget: opacity 1.0 → 0.0
+  /// - toWidget: opacity 0.0 → 1.0
+  /// - 微細なスケール効果で奥行き感を演出
+  Widget _buildAnimatedTransition({
+    required Animation<double> animation,
+    required Widget fromWidget,
+    required Widget toWidget,
+    required HeroFlightDirection direction,
+  }) {
+    // 方向に応じて適切なアニメーションカーブを選択
+    // push: easeOut - 最初速く、後でゆっくり（ユーザーの操作感を重視）
+    // pop: easeIn - 最初ゆっくり、後で速く（戻る操作の自然さを重視）
+    final curve =
+        direction == HeroFlightDirection.push
+            ? Curves.easeOutCubic
+            : Curves.easeInCubic;
+    final curvedValue = curve.transform(animation.value);
+
+    // 遷移方向に応じた適切なスケール効果の修正
+    // push: 詳細画面への移動 - 小さく始まって大きくなる (0.98 → 1.02)
+    // pop: 検索画面への戻り - 大きく始まって小さくなる (1.02 → 0.98)
+    final scaleValue =
+        direction == HeroFlightDirection.push
+            ? 0.98 +
+                (0.04 * curvedValue) // push: 0.98 → 1.02
+            : 1.02 - (0.04 * curvedValue); // pop: 1.02 → 0.98
+
+    return Transform.scale(
+      scale: scaleValue,
+      child: DecoratedBox(
+        decoration: uiBuilder.buildAnimationDecoration(animation),
+        child: Stack(
+          alignment: Alignment.center,
+          children:
+              direction == HeroFlightDirection.push
+                  ? [
+                    // push: 詳細画面へ - 検索画面のカードが下、詳細画面のカードが上
+                    Opacity(
+                      opacity: 1.0 - curvedValue,
+                      child: fromWidget,
+                    ),
+                    Opacity(
+                      opacity: curvedValue,
+                      child: toWidget,
+                    ),
+                  ]
+                  : [
+                    // pop: 検索画面へ戻る - 詳細画面のカードが下、検索画面のカードが上
+                    Opacity(
+                      opacity: curvedValue,
+                      child: fromWidget,
+                    ),
+                    Opacity(
+                      opacity: 1.0 - curvedValue,
+                      child: toWidget,
+                    ),
+                  ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/widget/repository_hero_animation_monitor.dart
+++ b/lib/view/widget/repository_hero_animation_monitor.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_hero_animation_state.dart';
+
+/// Hero アニメーション監視の責任を担うクラス
+///
+/// Martin Fowler's Extract Class と Strategy Pattern を適用
+/// アニメーション監視のロジックを分離し、再利用可能にする
+class HeroAnimationMonitor {
+  HeroAnimationMonitor(this._state);
+
+  final HeroAnimationState _state;
+
+  /// Hero flight アニメーションの監視を開始
+  ///
+  /// HeroアニメーションのFlightの監視を開始
+  ///
+  /// Extract Method リファクタリングを適用
+  /// 複雑な監視ロジックを単一の責任を持つメソッドに分離
+  void monitorFlightAnimation(
+    Animation<double> animation,
+    HeroFlightDirection direction,
+  ) {
+    _state.startMonitoring();
+
+    // 現在の状態を遅延実行で反映（build中の呼び出しを避ける）
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _state.updateStatus(animation.status);
+    });
+
+    _attachStatusListener(animation);
+    _attachValueListener(animation);
+  }
+
+  /// コントローラーアニメーションの監視を開始
+  void monitorControllerAnimation(AnimationController controller) {
+    _attachStatusListener(controller);
+    _attachValueListener(controller);
+  }
+
+  /// 状態変化リスナーの追加
+  ///
+  /// Extract Method リファクタリングを適用
+  /// リスナー追加の重複コードを統合
+  void _attachStatusListener(Animation<double> animation) {
+    animation.addStatusListener(_state.updateStatus);
+  }
+
+  /// 値変化リスナーの追加
+  ///
+  /// Extract Method リファクタリングを適用
+  /// 必要に応じて拡張可能な構造に変更
+  void _attachValueListener(Animation<double> animation) {
+    animation.addListener(() {
+      // 値の変化に応じた処理（必要に応じて拡張）
+      _onAnimationValueChanged(animation.value, animation.status);
+    });
+  }
+
+  /// アニメーション値変化時の処理
+  ///
+  /// Template Method パターンの適用ポイント
+  /// サブクラスでオーバーライド可能
+  void _onAnimationValueChanged(double value, AnimationStatus status) {
+    // デフォルトでは何もしない
+    // 必要に応じてサブクラスで実装
+  }
+
+  /// 監視を停止
+  void stopMonitoring() {
+    _state.stopMonitoring();
+  }
+
+  /// 状態をリセット
+  void reset() {
+    _state.reset();
+  }
+}

--- a/lib/view/widget/repository_hero_animation_state.dart
+++ b/lib/view/widget/repository_hero_animation_state.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+/// Hero アニメーションの状態を管理するクラス
+///
+/// Martin Fowler's Extract Class リファクタリングを適用
+/// アニメーション状態の管理責任を単一のクラスに集約
+class HeroAnimationState extends ChangeNotifier {
+  AnimationStatus? _lastAnimationStatus;
+  var _isMonitoring = false;
+  var _isDisposed = false;
+
+  /// アニメーションが完了しているかどうか
+  bool get isCompleted => _lastAnimationStatus == AnimationStatus.completed;
+
+  /// アニメーションが進行中かどうか
+  bool get isInProgress =>
+      _lastAnimationStatus == AnimationStatus.forward ||
+      _lastAnimationStatus == AnimationStatus.reverse;
+
+  /// アニメーションが初期状態かどうか
+  bool get isDismissed => _lastAnimationStatus == AnimationStatus.dismissed;
+
+  /// 現在の状態
+  AnimationStatus? get currentStatus => _lastAnimationStatus;
+
+  /// 監視中かどうか
+  bool get isMonitoring => _isMonitoring;
+
+  /// アニメーション状態を更新
+  void updateStatus(AnimationStatus status) {
+    if (_lastAnimationStatus != status) {
+      _lastAnimationStatus = status;
+
+      // build中の呼び出しを避けるため、フレーム後に通知を延期
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        // dispose済みでない場合のみ通知
+        if (!_isDisposed) {
+          notifyListeners();
+        }
+      });
+    }
+  }
+
+  /// 監視開始
+  void startMonitoring() {
+    _isMonitoring = true;
+
+    // build中の呼び出しを避けるため、フレーム後に通知を延期
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // dispose済みでない場合のみ通知
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    });
+  }
+
+  /// 監視終了
+  void stopMonitoring() {
+    _isMonitoring = false;
+    // build中の呼び出しを避けるため、フレーム後に通知を延期
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // dispose済みでない場合のみ通知
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    });
+  }
+
+  /// 状態をリセット
+  void reset() {
+    _lastAnimationStatus = null;
+    _isMonitoring = false;
+    // build中の呼び出しを避けるため、フレーム後に通知を延期
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // dispose済みでない場合のみ通知
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}

--- a/lib/view/widget/repository_layout_strategy.dart
+++ b/lib/view/widget/repository_layout_strategy.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/owner_icon.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_info_view.dart';
+
+/// レイアウト判定の戦略インターフェース
+///
+/// Flutter最適化されたStrategy Pattern を適用
+/// StatelessWidgetベースで効率的なウィジェットツリーを構築
+abstract class LayoutStrategyWidget extends StatelessWidget {
+  const LayoutStrategyWidget({required this.repository, super.key});
+
+  final Repository repository;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// MediaQuery ベースのレイアウト判定戦略
+///
+/// StatelessWidgetベースのStrategy Pattern
+/// アニメーション中の安定した判定に特化
+class MediaQueryLayoutStrategy extends LayoutStrategyWidget {
+  const MediaQueryLayoutStrategy({required super.repository, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    // final availableWidth = screenWidth - 32; // マージンとパディングを考慮
+
+    return _createLayoutWidget(screenWidth);
+  }
+
+  Widget _createLayoutWidget(double availableWidth) {
+    if (availableWidth >= NumberData.horizontalLayoutThresholdWithoutPadding) {
+      return RepositoryInfoHorizontalLayout(repository: repository);
+    } else {
+      return RepositoryInfoVerticalLayout(repository: repository);
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// LayoutBuilder ベースのレイアウト判定戦略
+///
+/// StatelessWidgetベースのStrategy Pattern
+/// アニメーション完了後の正確な判定に特化
+class LayoutBuilderLayoutStrategy extends LayoutStrategyWidget {
+  const LayoutBuilderLayoutStrategy({required super.repository, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return _createLayoutWidget(constraints.maxWidth);
+      },
+    );
+  }
+
+  Widget _createLayoutWidget(double width) {
+    if (width >= NumberData.horizontalLayoutThresholdWithoutPadding) {
+      return RepositoryInfoHorizontalLayout(repository: repository);
+    } else {
+      return RepositoryInfoVerticalLayout(repository: repository);
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// レイアウト戦略を管理するファクトリークラス
+///
+/// StatelessWidgetベースのFactory Method Pattern
+/// アニメーション状態に応じて適切な戦略ウィジェットを生成
+///
+/// Note: このクラスは名前空間として機能し、インスタンス化を想定していません
+mixin LayoutStrategyFactory {
+  static LayoutStrategyWidget createStrategy({
+    required bool isAnimationInProgress,
+    required bool isAnimationCompleted,
+    required Repository repository,
+  }) {
+    if (isAnimationInProgress) {
+      return MediaQueryLayoutStrategy(repository: repository);
+    } else {
+      return LayoutBuilderLayoutStrategy(repository: repository);
+    }
+  }
+}
+
+/// リポジトリ情報の横方向に長いレイアウト用のウィジェット
+///
+/// Martin Fowler's Extract Class を適用
+/// レイアウト責任を分離し、再利用性を向上
+class RepositoryInfoHorizontalLayout extends StatelessWidget {
+  const RepositoryInfoHorizontalLayout({required this.repository, super.key});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        RepositoryTitle(repository: repository),
+        const SizedBox(height: 16),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            OwnerIcon(repository: repository, diameter: 80),
+            const SizedBox(width: 24),
+            Expanded(
+              child: RepositoryDetailsInfoView(repository: repository),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリ情報の縦方向に長いレイアウト用のウィジェット
+///
+/// Martin Fowler's Extract Class を適用
+/// レイアウト責任を分離し、再利用性を向上
+class RepositoryInfoVerticalLayout extends StatelessWidget {
+  const RepositoryInfoVerticalLayout({required this.repository, super.key});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        OwnerIcon(repository: repository, diameter: 80),
+        const SizedBox(height: 12),
+        RepositoryTitle(repository: repository),
+        const SizedBox(height: 16),
+        RepositoryDetailsInfoView(repository: repository),
+      ],
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}
+
+/// リポジトリのタイトルを表示するウィジェット
+///
+/// Martin Fowler's Extract Class を適用
+/// タイトル表示の責任を分離し、統一したスタイルを適用
+///
+/// テキストスタイル:
+/// - 太字ヘッドライン
+/// - 最大2行表示
+/// - オーバーフロー時は省略記号
+/// - 中央揃え
+class RepositoryTitle extends StatelessWidget {
+  const RepositoryTitle({required this.repository, super.key});
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      repository.name,
+      style: theme.textTheme.headlineSmall?.copyWith(
+        fontWeight: FontWeight.bold,
+      ),
+      overflow: TextOverflow.ellipsis,
+      maxLines: 2,
+      textAlign: TextAlign.center,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+  }
+}

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -27,66 +27,58 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
   Widget build(BuildContext context) {
     final repositoriesAsyncValue = ref.watch(repositoriesSearchResultProvider);
 
-    if (repositoriesAsyncValue.isLoading) {
-      return const Center(
-        child: CircularProgressIndicator(),
-      );
-    }
-    if (repositoriesAsyncValue.hasError) {
-      return Center(
-        child: Text(
-          'エラーが発生しました: ${repositoriesAsyncValue.error}',
-          style: const TextStyle(color: Colors.red),
-        ),
-      );
-    }
-    if (repositoriesAsyncValue.isRefreshing) {
-      return const Center(
-        child: CircularProgressIndicator(),
-      );
-    }
-
-    final repositories = repositoriesAsyncValue.requireValue;
-
-    if (repositories.isEmpty) {
-      return const Center(
-        child: Text('該当するリポジトリはありません'),
-      );
-    }
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final columnCount = (constraints.maxWidth /
-                NumberData.horizontalLayoutThreshold)
-            .floor()
-            .clamp(1, 4);
-        final rowCount = (repositories.length / columnCount).ceil();
-        return ConstrainedBox(
-          constraints: BoxConstraints(
-            maxWidth: NumberData.horizontalLayoutThreshold * columnCount,
-          ),
-          child: ListView.builder(
-            controller: _scrollController,
-            itemCount: rowCount,
-            itemBuilder: (context, rowIndex) {
-              return Row(
-                children: List.generate(columnCount, (columnIndex) {
-                  final itemIndex = rowIndex * columnCount + columnIndex;
-                  if (itemIndex >= repositories.length) {
-                    return const SizedBox.expand();
-                  }
-                  return Flexible(
-                    child: _SearchResultListItem(
-                      repository: repositories[itemIndex],
-                    ),
-                  );
-                }),
-              );
-            },
+    switch (repositoriesAsyncValue) {
+      case AsyncError(:final error):
+        return Center(
+          child: Text(
+            error.toString(),
+            style: Theme.of(context).textTheme.bodyMedium,
           ),
         );
-      },
-    );
+      case AsyncData(:final value):
+        if (value.isEmpty) {
+          return const Center(
+            child: Text('該当するリポジトリはありません'),
+          );
+        }
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final columnCount = (constraints.maxWidth /
+                    NumberData.horizontalLayoutThreshold)
+                .floor()
+                .clamp(1, 4);
+            final rowCount = (value.length / columnCount).ceil();
+            return ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: NumberData.horizontalLayoutThreshold * columnCount,
+              ),
+              child: ListView.builder(
+                controller: _scrollController,
+                itemCount: rowCount,
+                itemBuilder: (context, rowIndex) {
+                  return Row(
+                    children: List.generate(columnCount, (columnIndex) {
+                      final itemIndex = rowIndex * columnCount + columnIndex;
+                      if (itemIndex >= value.length) {
+                        return const SizedBox.expand();
+                      }
+                      return Flexible(
+                        child: _SearchResultListItem(
+                          repository: value[itemIndex],
+                        ),
+                      );
+                    }),
+                  );
+                },
+              ),
+            );
+          },
+        );
+      case _:
+        return const Center(
+          child: CircularProgressIndicator(),
+        );
+    }
   }
 }
 

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -58,12 +56,11 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final columnCount = max(
-          (constraints.maxWidth / NumberData.horizontalLayoutThreshold).floor(),
-          1,
-        );
+        final columnCount = (constraints.maxWidth /
+                NumberData.horizontalLayoutThreshold)
+            .floor()
+            .clamp(1, 4);
         final rowCount = (repositories.length / columnCount).ceil();
-
         return ConstrainedBox(
           constraints: BoxConstraints(
             maxWidth: NumberData.horizontalLayoutThreshold * columnCount,

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -87,8 +87,13 @@ class AdaptiveRepositoryListView extends StatelessWidget {
                     return const SizedBox.expand();
                   }
                   return Expanded(
-                    child: _SearchResultListItem(
-                      repository: value[itemIndex],
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: columnCount > 1 ? 8 : 0,
+                      ),
+                      child: _SearchResultListItem(
+                        repository: value[itemIndex],
+                      ),
                     ),
                   );
                 }),

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -56,28 +58,35 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final columnCount =
-            (constraints.maxWidth / NumberData.textFieldConstraintWidth).ceil();
+        final columnCount = max(
+          (constraints.maxWidth / NumberData.horizontalLayoutThreshold).floor(),
+          1,
+        );
         final rowCount = (repositories.length / columnCount).ceil();
 
-        return ListView.builder(
-          controller: _scrollController,
-          itemCount: rowCount,
-          itemBuilder: (context, rowIndex) {
-            return Row(
-              children: List.generate(columnCount, (columnIndex) {
-                final itemIndex = rowIndex * columnCount + columnIndex;
-                if (itemIndex >= repositories.length) {
-                  return const Expanded(child: SizedBox.shrink());
-                }
-                return Expanded(
-                  child: _SearchResultListItem(
-                    repository: repositories[itemIndex],
-                  ),
-                );
-              }),
-            );
-          },
+        return ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: NumberData.horizontalLayoutThreshold * columnCount,
+          ),
+          child: ListView.builder(
+            controller: _scrollController,
+            itemCount: rowCount,
+            itemBuilder: (context, rowIndex) {
+              return Row(
+                children: List.generate(columnCount, (columnIndex) {
+                  final itemIndex = rowIndex * columnCount + columnIndex;
+                  if (itemIndex >= repositories.length) {
+                    return const SizedBox.expand();
+                  }
+                  return Flexible(
+                    child: _SearchResultListItem(
+                      repository: repositories[itemIndex],
+                    ),
+                  );
+                }),
+              );
+            },
+          ),
         );
       },
     );
@@ -85,7 +94,7 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
 }
 
 class _SearchResultListItem extends StatelessWidget {
-  const _SearchResultListItem({required this.repository});
+  const _SearchResultListItem({required this.repository, super.key});
 
   final Repository repository;
 
@@ -98,8 +107,6 @@ class _SearchResultListItem extends StatelessWidget {
       tag: 'repository-${repository.name}',
 
       child: Card(
-        // リポジトリのカード
-        elevation: 2,
         // カードの影の深さ
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),

--- a/lib/view/widget/search_result_list_view.dart
+++ b/lib/view/widget/search_result_list_view.dart
@@ -1,7 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/owner_icon.dart';
 
 class SearchResultListView extends ConsumerStatefulWidget {
   const SearchResultListView({super.key});
@@ -51,48 +54,80 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
       );
     }
 
-    return ListView.builder(
-      controller: _scrollController,
-      itemCount: repositories.length,
-      itemBuilder: (context, index) {
-        final repository = repositories[index];
-        return Hero(
-          // ヒーローアニメーションを使用してリポジトリのリストを表示
-          // 詳細画面のHeroと同一のタグを使用することでアニメーションを実現している
-          transitionOnUserGestures: true,
-          tag: 'repository-${repository.name}',
-          child: Card(
-            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            child: ListTile(
-              leading:
-                  repository.owner == null
-                      ? const CircleAvatar(
-                        backgroundColor: Colors.grey,
-                        child: Icon(Icons.person, color: Colors.white),
-                      )
-                      : CircleAvatar(
-                        backgroundColor: const Color(0x00000000),
-                        backgroundImage: NetworkImage(
-                          repository.owner!.avatarUrl,
-                        ),
-                      ),
-              title: Text(
-                repository.name,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              trailing: const Icon(Icons.chevron_right),
-              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-              onTap: () async {
-                await GoRouter.of(
-                  context,
-                ).pushNamed('details', extra: repository);
-              },
-            ),
-          ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columnCount =
+            (constraints.maxWidth / NumberData.textFieldConstraintWidth).ceil();
+        final rowCount = (repositories.length / columnCount).ceil();
+
+        return ListView.builder(
+          controller: _scrollController,
+          itemCount: rowCount,
+          itemBuilder: (context, rowIndex) {
+            return Row(
+              children: List.generate(columnCount, (columnIndex) {
+                final itemIndex = rowIndex * columnCount + columnIndex;
+                if (itemIndex >= repositories.length) {
+                  return const Expanded(child: SizedBox.shrink());
+                }
+                return Expanded(
+                  child: _SearchResultListItem(
+                    repository: repositories[itemIndex],
+                  ),
+                );
+              }),
+            );
+          },
         );
       },
     );
+  }
+}
+
+class _SearchResultListItem extends StatelessWidget {
+  const _SearchResultListItem({required this.repository});
+
+  final Repository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Hero(
+      // ヒーローアニメーションを使用してリポジトリのリストを表示
+      // 詳細画面のHeroと同一のタグを使用することでアニメーションを実現している
+      transitionOnUserGestures: true,
+      tag: 'repository-${repository.name}',
+
+      child: Card(
+        // リポジトリのカード
+        elevation: 2,
+        // カードの影の深さ
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: ListTile(
+          leading: OwnerIcon(repository: repository, diameter: 20),
+          title: Text(
+            repository.name,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          onTap: () async {
+            await GoRouter.of(
+              context,
+            ).pushNamed('details', extra: repository);
+          },
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
   }
 }

--- a/lib/view/widget/search_text_field.dart
+++ b/lib/view/widget/search_text_field.dart
@@ -20,7 +20,7 @@ class SearchTextField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
       child: TextField(
         controller: controller ?? TextEditingController(),
         decoration: InputDecoration(

--- a/test/view/page/repository_details_page_test.dart
+++ b/test/view/page/repository_details_page_test.dart
@@ -72,7 +72,11 @@ void main() {
             findsOneWidget,
             reason: 'リポジトリ名が表示されるべき',
           );
-          expect(find.text('Dart'), findsOneWidget, reason: 'プログラミング言語が表示されるべき');
+          expect(
+            find.text('Dart'),
+            findsOneWidget,
+            reason: 'プログラミング言語が表示されるべき',
+          );
 
           // 日本語ロケールでのNumberFormat.compactフォーマットに合わせたテスト
           expect(

--- a/test/view/page/repository_details_page_test.dart
+++ b/test/view/page/repository_details_page_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
 import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/page/repository_details_page.dart';
 import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_card.dart';
+
+import '../../test_util/test_util.dart';
 
 void main() {
   group('RepositoryDetailsPage', () {
@@ -37,6 +40,135 @@ void main() {
       expect(find.byType(IconButton), findsOneWidget);
       expect(find.byType(RepositoryDetailsCard), findsOneWidget);
       expect(find.textContaining('リポジトリ'), findsWidgets);
+    });
+
+    group('ユーザー体験テスト', () {
+      testWidgets(
+        'ユーザーがリポジトリ詳細を表示した時、すべての重要情報が閲覧できる',
+        (tester) async {
+          // Given: 詳細なリポジトリ情報
+          const repository = Repository(
+            name: 'flutter-samples',
+            language: 'Dart',
+            stargazersCount: 15000,
+            watchersCount: 1000,
+            forksCount: 3000,
+            openIssuesCount: 42,
+            owner: Owner(
+              avatarUrl: 'https://example.com/avatar.png',
+            ),
+          );
+
+          // When: ユーザーが詳細ページにアクセスする
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositoryDetailsPage(repository: repository),
+          );
+
+          // Then: まず基本的な情報の存在を確認
+          expect(
+            find.text('flutter-samples'),
+            findsOneWidget,
+            reason: 'リポジトリ名が表示されるべき',
+          );
+          expect(find.text('Dart'), findsOneWidget, reason: 'プログラミング言語が表示されるべき');
+
+          // 日本語ロケールでのNumberFormat.compactフォーマットに合わせたテスト
+          expect(
+            find.text('1.5万'), // 15000 -> 1.5万（日本語ロケール）
+            findsOneWidget,
+            reason: 'スター数が表示されるべき',
+          );
+          expect(
+            find.text('3000'), // 3000はそのまま
+            findsOneWidget,
+            reason: 'フォーク数が表示されるべき',
+          );
+          expect(
+            find.text('42'),
+            findsOneWidget,
+            reason: '未解決Issue数が表示されるべき',
+          );
+          expect(
+            find.byType(RepositoryDetailsCard),
+            findsOneWidget,
+            reason: '詳細カードが表示されるべき',
+          );
+        },
+      );
+
+      testWidgets(
+        'ユーザーが戻るボタンを見つけることができる',
+        (tester) async {
+          // Given: リポジトリ詳細画面が表示されている
+          const repository = Repository(
+            name: 'test-repo',
+            language: 'JavaScript',
+            stargazersCount: 100,
+            watchersCount: 50,
+            forksCount: 20,
+            openIssuesCount: 5,
+          );
+
+          // When: 詳細ページが表示される
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositoryDetailsPage(repository: repository),
+          );
+
+          // Then: 戻るボタンが存在し、ユーザーがタップできる状態になっている
+          expect(
+            find.byIcon(Icons.arrow_back),
+            findsOneWidget,
+            reason: '戻るボタンがユーザーに表示されるべき',
+          );
+
+          // And: AppBarが存在する
+          expect(find.byType(AppBar), findsOneWidget, reason: 'AppBarが表示されるべき');
+        },
+      );
+
+      testWidgets(
+        '詳細表示に最小限の情報でも問題なく表示される',
+        (tester) async {
+          // Given: 最小限の情報を持つリポジトリ
+          const minimalRepository = Repository(
+            name: 'minimal-repo',
+            // 言語は null
+            stargazersCount: 0,
+            watchersCount: 0,
+            forksCount: 0,
+            openIssuesCount: 0,
+            // ownerもnull
+          );
+
+          // When: 詳細ページが表示される
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositoryDetailsPage(repository: minimalRepository),
+          );
+
+          // Then: クラッシュせず、アクセス可能な情報が表示される
+          expect(
+            find.text('minimal-repo'),
+            findsOneWidget,
+            reason: 'リポジトリ名は必須情報として表示されるべき',
+          );
+          expect(
+            find.textContaining('0'),
+            findsWidgets,
+            reason: '0のカウンタ値も適切に表示されるべき',
+          );
+          expect(
+            find.byType(RepositoryDetailsCard),
+            findsOneWidget,
+            reason: '詳細カードは表示されるべき',
+          );
+        },
+      );
     });
   });
 }

--- a/test/view/page/repository_search_page_test.dart
+++ b/test/view/page/repository_search_page_test.dart
@@ -104,5 +104,216 @@ void main() {
       );
       expect(find.text('リポジトリを検索'), findsOneWidget);
     });
+
+    group('ユーザー体験テスト', () {
+      testWidgets(
+        'ユーザーが検索ページにアクセスした時、検索に必要な要素がすべて利用可能',
+        (tester) async {
+          // When: ユーザーが検索ページを開く
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositorySearchPage(),
+          );
+
+          // Then: 検索に必要なUI要素が揃っている
+          expect(
+            find.byType(AppBar),
+            findsOneWidget,
+            reason: 'ページタイトルのAppBarが表示されるべき',
+          );
+          expect(
+            find.text('リポジトリ検索'),
+            findsOneWidget,
+            reason: 'ページタイトルが日本語で表示されるべき',
+          );
+          expect(
+            find.byType(TextField),
+            findsOneWidget,
+            reason: '検索用のテキストフィールドが提供されるべき',
+          );
+          expect(
+            find.byIcon(Icons.search),
+            findsOneWidget,
+            reason: '検索アイコンが表示されるべき',
+          );
+          expect(
+            find.byIcon(Icons.cancel),
+            findsOneWidget,
+            reason: 'キャンセルボタンが表示されるべき',
+          );
+
+          // And: 検索結果表示エリアが存在する
+          expect(
+            find.byType(Expanded),
+            findsOneWidget,
+            reason: '検索結果表示エリアが提供されるべき',
+          );
+        },
+      );
+
+      testWidgets(
+        'ユーザーがリポジトリ名を入力する時、リアルタイムフィードバックが提供される',
+        (tester) async {
+          // Given: 検索ページが表示されている
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositorySearchPage(),
+          );
+
+          // When: ユーザーが検索語を入力する
+          const searchTerm = 'flutter';
+          await tester.enterText(find.byType(TextField), searchTerm);
+          await tester.pump();
+
+          // Then: 入力内容が即座に表示される
+          expect(
+            find.text(searchTerm),
+            findsOneWidget,
+            reason: 'ユーザーの入力がリアルタイムで表示されるべき',
+          );
+
+          // When: ユーザーがEnterを押す
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pumpAndSettle();
+
+          // Then: 検索が実行される（UIの変化を確認）
+          expect(
+            find.byType(TextField),
+            findsOneWidget,
+            reason: '検索実行後もテキストフィールドが利用可能であるべき',
+          );
+        },
+      );
+
+      testWidgets(
+        'ユーザーが検索をクリアしたい時、簡単にリセットできる',
+        (tester) async {
+          // Given: 検索語が入力されている状態
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositorySearchPage(),
+          );
+
+          const searchTerm = 'test-repository';
+          await tester.enterText(find.byType(TextField), searchTerm);
+          await tester.pump();
+
+          // 入力が表示されていることを確認
+          expect(find.text(searchTerm), findsOneWidget, reason: '入力内容が表示されているべき');
+
+          // When: ユーザーがキャンセルボタンをタップする
+          await tester.tap(find.byIcon(Icons.cancel));
+          await tester.pump();
+
+          // Then: 検索フィールドがクリアされる
+          expect(
+            find.text(searchTerm),
+            findsNothing,
+            reason: 'キャンセル後は入力内容がクリアされるべき',
+          );
+
+          // And: 空の検索フィールドが表示される
+          final textField = tester.widget<TextField>(find.byType(TextField));
+          expect(
+            textField.controller?.text ?? '',
+            isEmpty,
+            reason: 'テキストフィールドが空になるべき',
+          );
+        },
+      );
+
+      testWidgets(
+        '多言語対応：英語ユーザーも適切にページを利用できる',
+        (tester) async {
+          // When: 英語ロケールでページを表示
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('en'),
+            home: const RepositorySearchPage(),
+          );
+
+          // Then: 英語でのUI要素が表示される
+          expect(
+            find.text('Search Repository'),
+            findsOneWidget,
+            reason: 'ページタイトルが英語で表示されるべき',
+          );
+          expect(
+            find.text('Search repositories'),
+            findsOneWidget,
+            reason: '検索フィールドのヒントが英語で表示されるべき',
+          );
+
+          // And: 機能的要素は言語に関係なく利用可能
+          expect(
+            find.byType(TextField),
+            findsOneWidget,
+            reason: '検索機能は言語に関係なく利用可能であるべき',
+          );
+          expect(
+            find.byIcon(Icons.search),
+            findsOneWidget,
+            reason: '検索アイコンは国際的に理解できるべき',
+          );
+        },
+      );
+
+      testWidgets(
+        'ユーザーがドロワーメニューにアクセスできる',
+        (tester) async {
+          // Given: 検索ページが表示されている
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositorySearchPage(),
+          );
+
+          // When: ユーザーがドロワーを開こうとする
+          expect(find.byType(AppBar), findsOneWidget, reason: 'AppBarが存在するべき');
+
+          // Then: ドロワーアクセス手段が提供されている
+          expect(
+            find.byType(Scaffold),
+            findsOneWidget,
+            reason: 'Scaffoldがドロワー機能を提供するべき',
+          );
+        },
+      );
+
+      testWidgets(
+        'アクセシビリティ：画面タップでフォーカスが適切に管理される',
+        (tester) async {
+          // Given: 検索ページが表示され、テキストフィールドにフォーカスがある
+          await pumpAppWithLocale(
+            tester: tester,
+            locale: const Locale('ja'),
+            home: const RepositorySearchPage(),
+          );
+
+          // フォーカスを設定
+          await tester.tap(find.byType(TextField));
+          await tester.pump();
+
+          // When: ユーザーが画面の空白部分をタップ
+          await tester.tap(find.byType(Scaffold));
+          await tester.pump();
+
+          // Then: フォーカスが外れる（GestureDetectorによる）
+          expect(
+            find.byType(TextField),
+            findsOneWidget,
+            reason: 'テキストフィールドは引き続き利用可能であるべき',
+          );
+          expect(
+            find.byType(GestureDetector),
+            findsWidgets,
+            reason: 'フォーカス管理のためのGestureDetector群が存在するべき',
+          );
+        },
+      );
+    });
   });
 }

--- a/test/view/page/repository_search_page_test.dart
+++ b/test/view/page/repository_search_page_test.dart
@@ -202,7 +202,11 @@ void main() {
           await tester.pump();
 
           // 入力が表示されていることを確認
-          expect(find.text(searchTerm), findsOneWidget, reason: '入力内容が表示されているべき');
+          expect(
+            find.text(searchTerm),
+            findsOneWidget,
+            reason: '入力内容が表示されているべき',
+          );
 
           // When: ユーザーがキャンセルボタンをタップする
           await tester.tap(find.byIcon(Icons.cancel));

--- a/test/view/widget/repository_card_ui_builder_test.dart
+++ b/test/view/widget/repository_card_ui_builder_test.dart
@@ -178,7 +178,7 @@ void main() {
       );
       expect(decoration.boxShadow, isNotEmpty, reason: 'シャドウ効果が設定されるべき');
       expect(
-        decoration.boxShadow!.first.color.alpha,
+        decoration.boxShadow!.first.color.a,
         greaterThan(0),
         reason: 'シャドウに透明度が設定されるべき',
       );

--- a/test/view/widget/repository_card_ui_builder_test.dart
+++ b/test/view/widget/repository_card_ui_builder_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_card_ui_builder.dart';
+
+import '../../test_util/test_util.dart';
+
+void main() {
+  group('リポジトリカードUI構築 - ユーザー体験テスト', () {
+    testWidgets(
+      'ユーザーがカードを見た時、リポジトリ情報が適切に表示される',
+      (tester) async {
+        // Given: 豊富な情報を持つリポジトリ
+        const repository = Repository(
+          name: 'awesome-flutter-app',
+          language: 'Dart',
+          stargazersCount: 25000,
+          watchersCount: 1500,
+          forksCount: 4000,
+          openIssuesCount: 125,
+          owner: Owner(avatarUrl: 'https://example.com/avatar.png'),
+        );
+
+        const uiBuilder = RepositoryCardUIBuilder(
+          repository: repository,
+          isHeroAnimationCompleted: true,
+          isHeroAnimationInProgress: false,
+        );
+
+        // When: UIビルダーでカードコンテンツを構築
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: Builder(
+              builder: uiBuilder.buildCardContent,
+            ),
+          ),
+        );
+
+        // Then: ユーザーが重要な情報を確認できる
+        expect(
+          find.text('awesome-flutter-app'),
+          findsOneWidget,
+          reason: 'リポジトリ名が表示されるべき',
+        );
+        expect(find.text('Dart'), findsOneWidget, reason: 'プログラミング言語が表示されるべき');
+        expect(
+          find.text('2.5万'),
+          findsOneWidget,
+          reason: 'スター数が日本語フォーマットで表示されるべき',
+        );
+        expect(find.text('4000'), findsOneWidget, reason: 'フォーク数が表示されるべき');
+        expect(find.text('125'), findsOneWidget, reason: 'イシュー数が表示されるべき');
+
+        // And: カード構造が適切に表示される
+        expect(
+          find.byType(Card),
+          findsWidgets,
+          reason: 'リポジトリ情報を含むカード群が表示されるべき',
+        );
+      },
+    );
+
+    testWidgets(
+      'アニメーション状態によってカードの見た目が変化する',
+      (tester) async {
+        // Given: 同じリポジトリデータで異なるアニメーション状態
+        const repository = Repository(
+          name: 'animation-test-repo',
+          language: 'JavaScript',
+          stargazersCount: 1000,
+          watchersCount: 100,
+          forksCount: 200,
+          openIssuesCount: 10,
+        );
+
+        // When: アニメーション進行中の状態
+        const inProgressBuilder = RepositoryCardUIBuilder(
+          repository: repository,
+          isHeroAnimationCompleted: false,
+          isHeroAnimationInProgress: true,
+        );
+
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: Builder(
+              builder: inProgressBuilder.buildCardContent,
+            ),
+          ),
+        );
+
+        // Then: アニメーション中でもコンテンツが表示される
+        expect(
+          find.text('animation-test-repo'),
+          findsOneWidget,
+          reason: 'アニメーション中でもリポジトリ名が表示されるべき',
+        );
+        expect(
+          find.byType(Card),
+          findsWidgets,
+          reason: 'アニメーション中でもカード群が表示されるべき',
+        );
+      },
+    );
+
+    testWidgets(
+      '最小限の情報でもクラッシュせずにUIが表示される',
+      (tester) async {
+        // Given: 最小限のリポジトリ情報
+        const minimalRepository = Repository(
+          name: 'minimal-info-repo',
+          // language, ownerは null
+          stargazersCount: 0,
+          watchersCount: 0,
+          forksCount: 0,
+          openIssuesCount: 0,
+        );
+
+        const uiBuilder = RepositoryCardUIBuilder(
+          repository: minimalRepository,
+          isHeroAnimationCompleted: true,
+          isHeroAnimationInProgress: false,
+        );
+
+        // When: 最小限情報でカードを構築
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: Builder(
+              builder: uiBuilder.buildCardContent,
+            ),
+          ),
+        );
+
+        // Then: エラーなくUIが表示される
+        expect(
+          find.text('minimal-info-repo'),
+          findsOneWidget,
+          reason: 'リポジトリ名は必須として表示されるべき',
+        );
+        expect(find.text('0'), findsWidgets, reason: '0の値も適切に表示されるべき');
+        expect(find.byType(Card), findsWidgets, reason: 'カードUI群は常に表示されるべき');
+      },
+    );
+
+    test('アニメーション装飾の設定が適切に行われる', () {
+      // Given: UIビルダーとアニメーションオブジェクト
+      const repository = Repository(
+        name: 'decoration-test',
+        stargazersCount: 100,
+        watchersCount: 50,
+        forksCount: 25,
+        openIssuesCount: 5,
+      );
+
+      const uiBuilder = RepositoryCardUIBuilder(
+        repository: repository,
+        isHeroAnimationCompleted: false,
+        isHeroAnimationInProgress: true,
+      );
+
+      // Mock Animation
+      const mockAnimation = AlwaysStoppedAnimation<double>(0.5);
+
+      // When: アニメーション装飾を構築
+      final decoration = uiBuilder.buildAnimationDecoration(mockAnimation);
+
+      // Then: 適切な装飾設定が生成される
+      expect(
+        decoration.borderRadius,
+        equals(BorderRadius.circular(16)),
+        reason: '角丸16pxが設定されるべき',
+      );
+      expect(decoration.boxShadow, isNotEmpty, reason: 'シャドウ効果が設定されるべき');
+      expect(
+        decoration.boxShadow!.first.color.alpha,
+        greaterThan(0),
+        reason: 'シャドウに透明度が設定されるべき',
+      );
+    });
+  });
+}

--- a/test/view/widget/repository_hero_animation_test.dart
+++ b/test/view/widget/repository_hero_animation_test.dart
@@ -1,0 +1,315 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/owner.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_details_card.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/search_result_list_view.dart';
+
+import '../../test_util/test_util.dart';
+
+void main() {
+  group('HeroアニメーションのUXテスト', () {
+    testWidgets(
+      'ユーザーがリポジトリリストから詳細画面に遷移する時、自然なアニメーションが実行される',
+      (tester) async {
+        // Given: ユーザーがリポジトリ検索結果を見ている
+        const testRepository = Repository(
+          name: 'flutter',
+          language: 'Dart',
+          stargazersCount: 100000,
+          watchersCount: 5000,
+          forksCount: 15000,
+          openIssuesCount: 500,
+          owner: Owner(avatarUrl: 'https://example.com/avatar.png'),
+        );
+
+        final searchResultScreen = Scaffold(
+          appBar: AppBar(title: const Text('検索結果')),
+          body: AdaptiveRepositoryListView(
+            value: const [testRepository],
+            scrollController: ScrollController(),
+          ),
+        );
+
+        final detailScreen = Scaffold(
+          appBar: AppBar(title: const Text('詳細')),
+          body: const RepositoryDetailsCard(repository: testRepository),
+        );
+
+        // When: ユーザーがアプリを開く
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: searchResultScreen,
+        );
+
+        // Then: リポジトリが表示される
+        expect(find.text('flutter'), findsOneWidget);
+        // AdaptiveRepositoryListView は
+        // repository.name のみ表示するため、languageは検証しない
+
+        // And: Hero アニメーションの準備ができている
+        final heroWidgetInList = find.byType(Hero).first;
+        expect(heroWidgetInList, findsOneWidget);
+
+        // When: ユーザーが詳細画面を表示する（模擬的な画面遷移）
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Navigator(
+              pages: [
+                MaterialPage<void>(
+                  key: const ValueKey('search'),
+                  child: searchResultScreen,
+                ),
+                MaterialPage<void>(
+                  key: const ValueKey('detail'),
+                  child: detailScreen,
+                ),
+              ],
+              onDidRemovePage: (route) => route.onPopInvoked(true, route),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Then: 詳細画面でも同じリポジトリ情報が表示される
+        expect(find.text('flutter'), findsOneWidget);
+        // Note: 詳細画面では language も表示されることを確認
+        expect(find.text('Dart'), findsOneWidget);
+
+        // And: Hero ウィジェットが適切に配置されている
+        final heroWidgetInDetail = find.byType(Hero);
+        expect(heroWidgetInDetail, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'リポジトリ名が同じならば同一のHeroタグが使用され、アニメーションが実行される',
+      (tester) async {
+        // Given: 同じ名前のリポジトリが2つの画面に存在する
+        const repositoryName = 'awesome-repo';
+        const testRepository = Repository(
+          name: repositoryName,
+          language: 'JavaScript',
+          stargazersCount: 42,
+          watchersCount: 12,
+          forksCount: 8,
+          openIssuesCount: 3,
+        );
+
+        // When: リスト画面のHeroウィジェットを確認
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: AdaptiveRepositoryListView(
+              value: const [testRepository],
+              scrollController: ScrollController(),
+            ),
+          ),
+        );
+
+        // Then: 適切なタグを持つHeroウィジェットが存在する
+        final listHero = tester.widget<Hero>(find.byType(Hero));
+        expect(listHero.tag, equals('repository-$repositoryName'));
+
+        // When: 詳細画面のHeroウィジェットを確認
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: const Scaffold(
+            body: RepositoryDetailsCard(repository: testRepository),
+          ),
+        );
+
+        // Then: 同じタグを持つHeroウィジェットが存在する
+        final detailHero = tester.widget<Hero>(find.byType(Hero));
+        expect(detailHero.tag, equals('repository-$repositoryName'));
+        expect(detailHero.tag, equals(listHero.tag));
+      },
+    );
+
+    testWidgets(
+      'ユーザーがジェスチャーでナビゲーションした場合もアニメーションが動作する',
+      (tester) async {
+        // Given: ユーザージェスチャーに対応したHeroアニメーション設定
+        const testRepository = Repository(
+          name: 'gesture-test-repo',
+          language: 'Swift',
+          stargazersCount: 777,
+          watchersCount: 111,
+          forksCount: 222,
+          openIssuesCount: 33,
+        );
+
+        // When: リスト画面を表示
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: AdaptiveRepositoryListView(
+              value: const [testRepository],
+              scrollController: ScrollController(),
+            ),
+          ),
+        );
+
+        // Then: transitionOnUserGestures が有効になっている
+        final listHero = tester.widget<Hero>(find.byType(Hero));
+        expect(listHero.transitionOnUserGestures, isTrue);
+
+        // When: 詳細画面を表示
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: const Scaffold(
+            body: RepositoryDetailsCard(repository: testRepository),
+          ),
+        );
+
+        // Then: 詳細画面でもユーザージェスチャーに対応している
+        final detailHero = tester.widget<Hero>(find.byType(Hero));
+        expect(detailHero.transitionOnUserGestures, isTrue);
+      },
+    );
+
+    testWidgets(
+      'リポジトリ情報がnullでも安全にHeroアニメーションが動作する',
+      (tester) async {
+        // Given: 最小限の情報しか持たないリポジトリ
+        const minimalRepository = Repository(
+          name: 'minimal-repo',
+          stargazersCount: 0,
+          watchersCount: 0,
+          forksCount: 0,
+          openIssuesCount: 0,
+          // language: null, owner: null
+        );
+
+        // When: 詳細画面を表示
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: const Scaffold(
+            body: RepositoryDetailsCard(repository: minimalRepository),
+          ),
+        );
+
+        // Then: エラーなくHeroウィジェットが表示される
+        expect(find.byType(Hero), findsOneWidget);
+        expect(find.text('minimal-repo'), findsOneWidget);
+
+        // And: デフォルトアイコンが表示される
+        expect(find.byIcon(Icons.person), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'カスタムflightShuttleBuilderが適切に設定されている',
+      (tester) async {
+        // Given: Hero アニメーションを持つリポジトリ詳細カード
+        const testRepository = Repository(
+          name: 'animation-test',
+          language: 'Flutter',
+          stargazersCount: 1000,
+          watchersCount: 500,
+          forksCount: 200,
+          openIssuesCount: 50,
+        );
+
+        // When: 詳細画面を表示
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: const Scaffold(
+            body: RepositoryDetailsCard(repository: testRepository),
+          ),
+        );
+
+        // Then: カスタムflightShuttleBuilderが設定されている
+        final heroWidget = tester.widget<Hero>(find.byType(Hero));
+        expect(heroWidget.flightShuttleBuilder, isNotNull);
+      },
+    );
+  });
+
+  group('Heroアニメーションのパフォーマンステスト', () {
+    testWidgets(
+      'アニメーション中に大量のrebuildが発生しない',
+      (tester) async {
+        // Given: アニメーション性能を測定するためのリポジトリ
+        const testRepository = Repository(
+          name: 'performance-test',
+          language: 'Dart',
+          stargazersCount: 50000,
+          watchersCount: 10000,
+          forksCount: 5000,
+          openIssuesCount: 1000,
+        );
+
+        var buildCount = 0;
+
+        // When: rebuild回数を計測できるウィジェットでラップ
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                buildCount++;
+                return const RepositoryDetailsCard(repository: testRepository);
+              },
+            ),
+          ),
+        );
+
+        final initialBuildCount = buildCount;
+
+        // アニメーションをシミュレート
+        await tester.pump(const Duration(milliseconds: 16));
+        await tester.pump(const Duration(milliseconds: 16));
+        await tester.pump(const Duration(milliseconds: 16));
+
+        // Then: 過度なrebuildが発生していない
+        expect(buildCount - initialBuildCount, lessThan(10));
+      },
+    );
+  });
+
+  group('Heroアニメーションのアクセシビリティテスト', () {
+    testWidgets(
+      'アクセシビリティ機能が有効でもアニメーションが正常に動作する',
+      (tester) async {
+        // Given: アクセシビリティ設定でアニメーション無効
+        const testRepository = Repository(
+          name: 'accessibility-test',
+          language: 'Python',
+          stargazersCount: 123,
+          watchersCount: 45,
+          forksCount: 67,
+          openIssuesCount: 8,
+        );
+
+        // When: 詳細画面を表示（アニメーション無効設定）
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: const MediaQuery(
+            data: MediaQueryData(
+              disableAnimations: true, // アニメーション無効
+            ),
+            child: Scaffold(
+              body: RepositoryDetailsCard(repository: testRepository),
+            ),
+          ),
+        );
+
+        // Then: アニメーション無効でもウィジェットが正常に表示される
+        expect(find.byType(Hero), findsOneWidget);
+        expect(find.text('accessibility-test'), findsOneWidget);
+        expect(find.text('Python'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/view/widget/repository_layout_strategy_test.dart
+++ b/test/view/widget/repository_layout_strategy_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_flutter_engineer_codecheck/domain/model/git_hub_search_api/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/view/widget/repository_layout_strategy.dart';
+
+import '../../test_util/test_util.dart';
+
+void main() {
+  group('リポジトリレイアウト戦略 - ユーザー体験テスト', () {
+    testWidgets(
+      '画面幅に応じてユーザーが最適なレイアウトで情報を閲覧できる',
+      (tester) async {
+        // Given: 表示するリポジトリ情報
+        const repository = Repository(
+          name: 'layout-test-repo',
+          language: 'TypeScript',
+          stargazersCount: 5000,
+          watchersCount: 500,
+          forksCount: 1000,
+          openIssuesCount: 50,
+        );
+
+        // When: 狭い画面でレイアウト戦略を適用
+        await tester.binding.setSurfaceSize(const Size(400, 600)); // 狭い画面
+
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: LayoutStrategyFactory.createStrategy(
+              isAnimationInProgress: false,
+              isAnimationCompleted: true,
+              repository: repository,
+            ),
+          ),
+        );
+
+        // Then: コンテンツが適切に表示される
+        expect(
+          find.text('layout-test-repo'),
+          findsOneWidget,
+          reason: 'リポジトリ名が表示されるべき',
+        );
+        expect(
+          find.text('TypeScript'),
+          findsOneWidget,
+          reason: 'プログラミング言語が表示されるべき',
+        );
+        expect(find.text('5000'), findsOneWidget, reason: 'スター数が表示されるべき');
+
+        // And: レイアウトコンポーネントが存在する
+        expect(
+          find.byType(Column),
+          findsWidgets,
+          reason: 'レイアウト戦略でColumn構造が適用されるべき',
+        );
+      },
+    );
+
+    testWidgets(
+      'アニメーション中でも安定したレイアウトが提供される',
+      (tester) async {
+        // Given: アニメーション進行中のシナリオ
+        const repository = Repository(
+          name: 'animation-layout-test',
+          language: 'Go',
+          stargazersCount: 2000,
+          watchersCount: 200,
+          forksCount: 300,
+          openIssuesCount: 15,
+        );
+
+        // When: アニメーション進行中の戦略を適用
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: LayoutStrategyFactory.createStrategy(
+              isAnimationInProgress: true,
+              isAnimationCompleted: false,
+              repository: repository,
+            ),
+          ),
+        );
+
+        // Then: アニメーション中でも情報が表示される
+        expect(
+          find.text('animation-layout-test'),
+          findsOneWidget,
+          reason: 'アニメーション中でもリポジトリ名が表示されるべき',
+        );
+        expect(
+          find.text('Go'),
+          findsOneWidget,
+          reason: 'アニメーション中でも言語情報が表示されるべき',
+        );
+
+        // And: ウィジェットツリーが構築される
+        expect(
+          tester.allWidgets.isNotEmpty,
+          true,
+          reason: 'アニメーション中でもウィジェットが構築されるべき',
+        );
+      },
+    );
+
+    testWidgets(
+      '様々な画面サイズで一貫したユーザー体験が提供される',
+      (tester) async {
+        // Given: テスト用リポジトリ
+        const repository = Repository(
+          name: 'responsive-test',
+          language: 'Python',
+          stargazersCount: 15000,
+          watchersCount: 1000,
+          forksCount: 2500,
+          openIssuesCount: 100,
+        );
+
+        // Test Case 1: 非常に狭い画面
+        await tester.binding.setSurfaceSize(const Size(300, 500));
+
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(
+            body: LayoutStrategyFactory.createStrategy(
+              isAnimationInProgress: false,
+              isAnimationCompleted: true,
+              repository: repository,
+            ),
+          ),
+        );
+
+        expect(
+          find.text('responsive-test'),
+          findsOneWidget,
+          reason: '狭い画面でもリポジトリ名が表示されるべき',
+        );
+
+        // Test Case 2: 広い画面
+        await tester.binding.setSurfaceSize(const Size(800, 600));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('responsive-test'),
+          findsOneWidget,
+          reason: '広い画面でもリポジトリ名が表示されるべき',
+        );
+        expect(
+          find.text('1.5万'),
+          findsOneWidget,
+          reason: '広い画面でもスター数が適切にフォーマットされるべき',
+        );
+      },
+    );
+
+    testWidgets(
+      'ファクトリーパターンによるウィジェット生成が適切に動作する',
+      (tester) async {
+        // Given: ファクトリーメソッドのテスト
+        const repository = Repository(
+          name: 'factory-pattern-test',
+          language: 'Rust',
+          stargazersCount: 3000,
+          watchersCount: 300,
+          forksCount: 600,
+          openIssuesCount: 25,
+        );
+
+        // When: 異なる状態でファクトリーを使用
+        final strategyWidget = LayoutStrategyFactory.createStrategy(
+          isAnimationInProgress: false,
+          isAnimationCompleted: true,
+          repository: repository,
+        );
+
+        await pumpAppWithLocale(
+          tester: tester,
+          locale: const Locale('ja'),
+          home: Scaffold(body: strategyWidget),
+        );
+
+        // Then: ファクトリーで生成されたウィジェットが正常に動作
+        expect(
+          find.text('factory-pattern-test'),
+          findsOneWidget,
+          reason: 'ファクトリーで生成されたウィジェットが表示されるべき',
+        );
+        expect(
+          find.text('Rust'),
+          findsOneWidget,
+          reason: 'ファクトリーで生成されたウィジェットに言語情報が含まれるべき',
+        );
+        expect(strategyWidget, isA<Widget>(), reason: 'ファクトリーは有効なウィジェットを返すべき');
+      },
+    );
+  });
+}

--- a/test/view/widget/search_result_list_view_test.dart
+++ b/test/view/widget/search_result_list_view_test.dart
@@ -74,7 +74,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      expect(find.textContaining('エラーが発生しました'), findsOneWidget);
+      expect(find.textContaining('Exception: error'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## 概要

UI設計全体の改善とモジュール化を行いました。

修正量としては大きいですが、UIデザインの変更を一貫して修正したかったので全体の更新をこのPRに入れようと思います。

## 関連Issue

#56 

## 変更内容

### UI/UX改善
- **複数列リストビューの列間マージンを16ptに設定** (`lib/view/widget/search_result_list_view.dart`)
  - 各アイテムに水平方向8ptのパディングを追加（隣接する列間で合計16pt）
  - 単列表示時は従来通りパディングなしを維持
- **検索画面の自動複数列表示対応** (`lib/view/page/repository_search_page.dart`)
  - 画面幅に応じて自動的に列数を調整（最大4列）
  - レスポンシブデザインの実装

### アーキテクチャ改善
- **コンポーネントのモジュール化**
  - `OwnerIcon`の共通コンポーネント化 (`lib/view/widget/owner_icon.dart`)
  - `RepositoryDetailsInfoView`の外部ファイル化 (`lib/view/widget/repository_details_info_view.dart`)
  - `RepositoryCardUIBuilder`の作成 (`lib/view/widget/repository_card_ui_builder.dart`)

- **レイアウト戦略の抽象化**
  - `RepositoryLayoutStrategy`によるレイアウトロジックの分離 (`lib/view/widget/repository_layout_strategy.dart`)
  - `RepositoryHeroAnimationBuilder`でアニメーション処理を統合 (`lib/view/widget/repository_hero_animation_builder.dart`)

### データ処理改善
- **AsyncValueの扱いをSwitch文に変更** (`lib/view/widget/search_result_list_view.dart`)
  - Riverpod公式推奨のパターンに準拠
  - エラーハンドリングの改善

- **定数管理の改善** (`lib/static/number_data.dart`)
  - レイアウト関連の定数を一元管理
  - `horizontalLayoutThreshold`の追加

### テストの充実
- **新規ウィジェットテストの追加**
  - `test/view/widget/repository_card_ui_builder_test.dart`
  - `test/view/widget/repository_hero_animation_test.dart`
  - `test/view/widget/repository_layout_strategy_test.dart`
- **ページレベルテストの改善**
  - `test/view/page/repository_details_page_test.dart`
  - `test/view/page/repository_search_page_test.dart`

### ドキュメント
- **UIデザイン仕様書の追加** (`docs/UIデザイン.drawio`)
  - 画面設計とレイアウト仕様の明文化

## 動作確認内容

- 画面幅に応じてリストが1〜4列で自動調整されることを確認
- 複数列表示時に列間に16ptのマージンが適切に設定されることを確認
- 単列表示時は従来通りのレイアウトが維持されることを確認
- Heroアニメーションが正常に動作することを確認
- 各種テストが通ることを確認

## 補足

- 列間マージンは各アイテムに8ptずつの水平パディングを設定することで実現（合計16pt）
- モジュール化により保守性とテスタビリティが向上
- レスポンシブデザインにより様々な画面サイズに