### PR TITLE
GitHub Copilotのプロンプトファイルやインストラクションファイルを追加

### DIFF
--- a/.github/instructions/base.instructions.md
+++ b/.github/instructions/base.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: 'all'
+description: 'このプロジェクトの開発に関する基本的な指示を提供します。'
+---
+
+このプロジェクトでは Flutterを使用しています。
+状態管理には Riverpod を使用しています。（自動生成を利用します。）
+コードの構成は、機能ごとに分けた「Feature-first」構成を採用しています。
+コードの更新に関わる設計上の情報については [documents/ARCHITECTURE.md](/documents/ARCHITECTURE.md) を参照してください。
+コーディング規約や命名規則については、 [documents/styles_guideline.md](/documents/styles_guideline.md) を参照してください。
+文言の追加や変更については、[how-to-add-strings.md](/how-to-add-strings.md) を参照してください。

--- a/.github/prompts/commit_done_files.prompt.md
+++ b/.github/prompts/commit_done_files.prompt.md
@@ -1,0 +1,38 @@
+---
+mode: agent
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+---
+
+ここまでの変更内容を単一の機能に分けてコミットして下さい。
+
+■注意点
+- 実例についてはこれまでのコミットメッセージを参考にして下さい
+- コミットメッセージは日本語で書いて下さい。
+- 単一の機能の単位で分けてコミットして下さい。
+  - 例えば、機能追加とバグ修正を同時に行った場合は、それぞれ別のコミットに分けて下さい。
+
+まず、現在のブランチを確認して下さい。
+次に、`origin/main`ブランチと現在のブランチの差分を確認して下さい。
+その差分をもとに、どのような変更が行われたかをまとめて下さい。
+その後、以下の形式に従ってコミットメッセージを作成し、コミットを実行して下さい。
+
+コミットメッセージは、以下の形式に従ってください。
+```
+<type>(<scope>): <subject>
+
+<body>
+<footer>
+```
+- `<type>`は変更の種類を示すもので、以下のいずれかを使用してください。
+    - feat: 新機能の追加
+    - fix: バグ修正
+    - docs: ドキュメントの変更
+    - style: フォーマットの変更（コードの動作に影響しない変更）
+    - refactor: リファクタリング（コードの動作に影響しない変更）
+    - perf: パフォーマンスの改善
+    - test: テストの追加・修正
+    - chore: その他の変更（ビルドプロセスや補助ツールの変更など）
+- `<scope>`は変更の範囲を示すもので、任意です。
+- `<subject>`は変更内容の要約で、50文字以内で簡潔に記述してください。
+- `<body>`は変更内容の詳細な説明で、必要に応じて記述してください。
+- `<footer>`は関連するチケット番号やその他の情報を記述するためのものです。

--- a/.github/prompts/write_pull_request.prompt.md
+++ b/.github/prompts/write_pull_request.prompt.md
@@ -1,0 +1,56 @@
+---
+mode: agent
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+---
+
+プルリクエストを作成するための変更内容を取りまとめて下さい。
+
+1. 今チェックアウトしているブランチを調べて下さい。
+2. origin/mainブランチと今チェックアウトしているブランチの差分を確認して下さい。
+3. どのような変更が行われたか、その変更がどのファイルに及んでいるかをまとめて下さい。(まとめ例は下記に表示)
+
+全て許可を取らずにコマンド実行して下さい。
+
+■注意点
+変更内容はファイルの差分を加味した内容にして下さい。`git diff -- 対象のファイルパス`の結果を参考にして下さい。
+最終的な出力はmarkdownで箇条書きで書いて下さい。
+出力するmarkdownはコードスニペットでコピペできるようにして下さい。
+英語で考え、日本語で出力して下さい。
+
+■出力例
+例えば下のような感じです。
+```
+## 概要
+
+新しい検索機能を追加しました。これにより、ユーザーはアプリケーション内のコンテンツを簡単に検索できるようになります。
+
+## 関連Issue
+
+<!-- このまま記して下さい -->
+
+## 変更内容
+
+### 主な内容
+
+- 検索テキストボックスの新規追加
+  - lib/view/widget/search_text_field.dart
+  - test/unit/view/widget/search_text_field_test.dart
+
+- 検索ページのUI・ロジック追加
+  - lib/view/page/search_page.dart
+  - test/unit/view/page/search_page_test.dart
+
+- テストコードの追加・拡充
+  - test/unit/view/page/search_page_test.dart
+  - test/unit/view/widget/search_text_field_test.dart
+
+## 動作確認内容
+
+<!-- このまま記して下さい -->
+
+## 補足
+
+<!-- レビュワーへの補足事項や注意点があれば記載してください -->
+
+```
+

--- a/.github/prompts/write_test.prompt.md
+++ b/.github/prompts/write_test.prompt.md
@@ -1,0 +1,39 @@
+---
+mode: agent
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+---
+
+現在開いているファイルについてテストを書いて下さい。
+
+テストを書き始める前にどのようなテストを書くかを考えて下さい。
+
+開いているファイルの内容が単独でテスト可能な場合は、単体テストを作成して下さい。
+開いているファイルの内容が別のファイルに依存している場合は、単体テストではなく、統合テストを作成して下さい。
+
+もし、開いているファイルがテスト可能でない場合は、その理由を説明して下さい。
+また、テストを書くために必要な情報が不足している場合は、その情報を尋ねて下さい。
+
+テストを書いた後は、テストを実行し、全てのテストが通ることを確認して下さい。
+もしテストが通らなかった場合は、どのテストが失敗したかを確認し、必要に応じて修正を行って下さい。
+
+以下のことに必ず従って下さい
+- DON'T
+  - プロダクトコードを変更しないで下さい。
+  - テストの実行に必要なコードを変更しないで下さい。
+  - テストの実行に必要なファイルを削除しないで下さい。
+  - テストの実行に必要なファイルを追加しないで下さい。
+  - 既存のテストを変更しないで下さい。
+
+テストを書く際には、以下の点に注意して下さい。
+- テストは、開いているファイルの機能を検証するものであり、実際の動作を模倣するものではありません。
+- テストは、開いているファイルの機能を検証するために必要な最小限の情報を使用して下さい。
+
+テスト戦略については以下を参考にして下さい。
+- テストの考え方については Kent C. Dodds の「Testing Trophy」「Given When Thenパターン」を参考にして下さい。
+  - テスティングトロフィについて：https://kentcdodds.com/blog/static-vs-unit-vs-integration-vs-e2e-tests
+  - テストのバッドプラクティス：https://kentcdodds.com/blog/common-testing-mistakes
+
+- テストの書き方については、以下のリソースを参考にして下さい。
+  - Flutterのテストガイド：https://flutter.dev/docs/testing
+  - Dartのテストガイド：https://dart.dev/guides/testing
+  - Mockitoの使い方：https://pub.dev/packages/mockito


### PR DESCRIPTION
## 概要

GitHub Copilotのプロンプトファイルやインストラクションファイルを追加

## 関連Issue

#79 

## 変更内容

- `/.github/prompts/*.prompt.md` (`/` を打つと使用可能)
  - テスト作成用のプロンプト
  - PRの内容を書くプロンプト
  - コミットを自動化してくれるプロンプト（一気に更新されるのでコミット整理は必須）
- `/.github/prompts/*.prompt.md` (前情報として入力される)
  - ベースとして必要な情報をまとめたインストラクションファイル

## 動作確認内容

<!-- 動作確認した内容や手順を記載してください -->

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
