### PR TITLE
Heroのtagの衝突問題を修正した

### DIFF
--- a/lib/features/repository_search/domain/entity/repository.dart
+++ b/lib/features/repository_search/domain/entity/repository.dart
@@ -15,6 +15,8 @@ sealed class Repository with _$Repository {
   @JsonSerializable(explicitToJson: true)
   const factory Repository({
     required String name,
+    @JsonKey(name: 'full_name') required String fullName,
+    required int id,
     @JsonKey(name: 'stargazers_count') required int stargazersCount,
     @JsonKey(name: 'watchers_count') required int watchersCount,
     @JsonKey(name: 'forks_count') required int forksCount,

--- a/lib/features/repository_search/domain/entity/repository.freezed.dart
+++ b/lib/features/repository_search/domain/entity/repository.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Repository {
 
- String get name;@JsonKey(name: 'stargazers_count') int get stargazersCount;@JsonKey(name: 'watchers_count') int get watchersCount;@JsonKey(name: 'forks_count') int get forksCount;@JsonKey(name: 'open_issues_count') int get openIssuesCount; Owner? get owner; String? get language;
+ String get name;@JsonKey(name: 'full_name') String get fullName; int get id;@JsonKey(name: 'stargazers_count') int get stargazersCount;@JsonKey(name: 'watchers_count') int get watchersCount;@JsonKey(name: 'forks_count') int get forksCount;@JsonKey(name: 'open_issues_count') int get openIssuesCount; Owner? get owner; String? get language;
 /// Create a copy of Repository
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $RepositoryCopyWith<Repository> get copyWith => _$RepositoryCopyWithImpl<Reposit
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Repository&&(identical(other.name, name) || other.name == name)&&(identical(other.stargazersCount, stargazersCount) || other.stargazersCount == stargazersCount)&&(identical(other.watchersCount, watchersCount) || other.watchersCount == watchersCount)&&(identical(other.forksCount, forksCount) || other.forksCount == forksCount)&&(identical(other.openIssuesCount, openIssuesCount) || other.openIssuesCount == openIssuesCount)&&(identical(other.owner, owner) || other.owner == owner)&&(identical(other.language, language) || other.language == language));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Repository&&(identical(other.name, name) || other.name == name)&&(identical(other.fullName, fullName) || other.fullName == fullName)&&(identical(other.id, id) || other.id == id)&&(identical(other.stargazersCount, stargazersCount) || other.stargazersCount == stargazersCount)&&(identical(other.watchersCount, watchersCount) || other.watchersCount == watchersCount)&&(identical(other.forksCount, forksCount) || other.forksCount == forksCount)&&(identical(other.openIssuesCount, openIssuesCount) || other.openIssuesCount == openIssuesCount)&&(identical(other.owner, owner) || other.owner == owner)&&(identical(other.language, language) || other.language == language));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,stargazersCount,watchersCount,forksCount,openIssuesCount,owner,language);
+int get hashCode => Object.hash(runtimeType,name,fullName,id,stargazersCount,watchersCount,forksCount,openIssuesCount,owner,language);
 
 @override
 String toString() {
-  return 'Repository(name: $name, stargazersCount: $stargazersCount, watchersCount: $watchersCount, forksCount: $forksCount, openIssuesCount: $openIssuesCount, owner: $owner, language: $language)';
+  return 'Repository(name: $name, fullName: $fullName, id: $id, stargazersCount: $stargazersCount, watchersCount: $watchersCount, forksCount: $forksCount, openIssuesCount: $openIssuesCount, owner: $owner, language: $language)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $RepositoryCopyWith<$Res>  {
   factory $RepositoryCopyWith(Repository value, $Res Function(Repository) _then) = _$RepositoryCopyWithImpl;
 @useResult
 $Res call({
- String name,@JsonKey(name: 'stargazers_count') int stargazersCount,@JsonKey(name: 'watchers_count') int watchersCount,@JsonKey(name: 'forks_count') int forksCount,@JsonKey(name: 'open_issues_count') int openIssuesCount, Owner? owner, String? language
+ String name,@JsonKey(name: 'full_name') String fullName, int id,@JsonKey(name: 'stargazers_count') int stargazersCount,@JsonKey(name: 'watchers_count') int watchersCount,@JsonKey(name: 'forks_count') int forksCount,@JsonKey(name: 'open_issues_count') int openIssuesCount, Owner? owner, String? language
 });
 
 
@@ -66,10 +66,12 @@ class _$RepositoryCopyWithImpl<$Res>
 
 /// Create a copy of Repository
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? stargazersCount = null,Object? watchersCount = null,Object? forksCount = null,Object? openIssuesCount = null,Object? owner = freezed,Object? language = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? fullName = null,Object? id = null,Object? stargazersCount = null,Object? watchersCount = null,Object? forksCount = null,Object? openIssuesCount = null,Object? owner = freezed,Object? language = freezed,}) {
   return _then(_self.copyWith(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,stargazersCount: null == stargazersCount ? _self.stargazersCount : stargazersCount // ignore: cast_nullable_to_non_nullable
+as String,fullName: null == fullName ? _self.fullName : fullName // ignore: cast_nullable_to_non_nullable
+as String,id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,stargazersCount: null == stargazersCount ? _self.stargazersCount : stargazersCount // ignore: cast_nullable_to_non_nullable
 as int,watchersCount: null == watchersCount ? _self.watchersCount : watchersCount // ignore: cast_nullable_to_non_nullable
 as int,forksCount: null == forksCount ? _self.forksCount : forksCount // ignore: cast_nullable_to_non_nullable
 as int,openIssuesCount: null == openIssuesCount ? _self.openIssuesCount : openIssuesCount // ignore: cast_nullable_to_non_nullable
@@ -98,10 +100,12 @@ $OwnerCopyWith<$Res>? get owner {
 
 @JsonSerializable(explicitToJson: true)
 class _Repository implements Repository {
-  const _Repository({required this.name, @JsonKey(name: 'stargazers_count') required this.stargazersCount, @JsonKey(name: 'watchers_count') required this.watchersCount, @JsonKey(name: 'forks_count') required this.forksCount, @JsonKey(name: 'open_issues_count') required this.openIssuesCount, this.owner, this.language});
+  const _Repository({required this.name, @JsonKey(name: 'full_name') required this.fullName, required this.id, @JsonKey(name: 'stargazers_count') required this.stargazersCount, @JsonKey(name: 'watchers_count') required this.watchersCount, @JsonKey(name: 'forks_count') required this.forksCount, @JsonKey(name: 'open_issues_count') required this.openIssuesCount, this.owner, this.language});
   factory _Repository.fromJson(Map<String, dynamic> json) => _$RepositoryFromJson(json);
 
 @override final  String name;
+@override@JsonKey(name: 'full_name') final  String fullName;
+@override final  int id;
 @override@JsonKey(name: 'stargazers_count') final  int stargazersCount;
 @override@JsonKey(name: 'watchers_count') final  int watchersCount;
 @override@JsonKey(name: 'forks_count') final  int forksCount;
@@ -122,16 +126,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Repository&&(identical(other.name, name) || other.name == name)&&(identical(other.stargazersCount, stargazersCount) || other.stargazersCount == stargazersCount)&&(identical(other.watchersCount, watchersCount) || other.watchersCount == watchersCount)&&(identical(other.forksCount, forksCount) || other.forksCount == forksCount)&&(identical(other.openIssuesCount, openIssuesCount) || other.openIssuesCount == openIssuesCount)&&(identical(other.owner, owner) || other.owner == owner)&&(identical(other.language, language) || other.language == language));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Repository&&(identical(other.name, name) || other.name == name)&&(identical(other.fullName, fullName) || other.fullName == fullName)&&(identical(other.id, id) || other.id == id)&&(identical(other.stargazersCount, stargazersCount) || other.stargazersCount == stargazersCount)&&(identical(other.watchersCount, watchersCount) || other.watchersCount == watchersCount)&&(identical(other.forksCount, forksCount) || other.forksCount == forksCount)&&(identical(other.openIssuesCount, openIssuesCount) || other.openIssuesCount == openIssuesCount)&&(identical(other.owner, owner) || other.owner == owner)&&(identical(other.language, language) || other.language == language));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,stargazersCount,watchersCount,forksCount,openIssuesCount,owner,language);
+int get hashCode => Object.hash(runtimeType,name,fullName,id,stargazersCount,watchersCount,forksCount,openIssuesCount,owner,language);
 
 @override
 String toString() {
-  return 'Repository(name: $name, stargazersCount: $stargazersCount, watchersCount: $watchersCount, forksCount: $forksCount, openIssuesCount: $openIssuesCount, owner: $owner, language: $language)';
+  return 'Repository(name: $name, fullName: $fullName, id: $id, stargazersCount: $stargazersCount, watchersCount: $watchersCount, forksCount: $forksCount, openIssuesCount: $openIssuesCount, owner: $owner, language: $language)';
 }
 
 
@@ -142,7 +146,7 @@ abstract mixin class _$RepositoryCopyWith<$Res> implements $RepositoryCopyWith<$
   factory _$RepositoryCopyWith(_Repository value, $Res Function(_Repository) _then) = __$RepositoryCopyWithImpl;
 @override @useResult
 $Res call({
- String name,@JsonKey(name: 'stargazers_count') int stargazersCount,@JsonKey(name: 'watchers_count') int watchersCount,@JsonKey(name: 'forks_count') int forksCount,@JsonKey(name: 'open_issues_count') int openIssuesCount, Owner? owner, String? language
+ String name,@JsonKey(name: 'full_name') String fullName, int id,@JsonKey(name: 'stargazers_count') int stargazersCount,@JsonKey(name: 'watchers_count') int watchersCount,@JsonKey(name: 'forks_count') int forksCount,@JsonKey(name: 'open_issues_count') int openIssuesCount, Owner? owner, String? language
 });
 
 
@@ -159,10 +163,12 @@ class __$RepositoryCopyWithImpl<$Res>
 
 /// Create a copy of Repository
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? stargazersCount = null,Object? watchersCount = null,Object? forksCount = null,Object? openIssuesCount = null,Object? owner = freezed,Object? language = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? fullName = null,Object? id = null,Object? stargazersCount = null,Object? watchersCount = null,Object? forksCount = null,Object? openIssuesCount = null,Object? owner = freezed,Object? language = freezed,}) {
   return _then(_Repository(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,stargazersCount: null == stargazersCount ? _self.stargazersCount : stargazersCount // ignore: cast_nullable_to_non_nullable
+as String,fullName: null == fullName ? _self.fullName : fullName // ignore: cast_nullable_to_non_nullable
+as String,id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,stargazersCount: null == stargazersCount ? _self.stargazersCount : stargazersCount // ignore: cast_nullable_to_non_nullable
 as int,watchersCount: null == watchersCount ? _self.watchersCount : watchersCount // ignore: cast_nullable_to_non_nullable
 as int,forksCount: null == forksCount ? _self.forksCount : forksCount // ignore: cast_nullable_to_non_nullable
 as int,openIssuesCount: null == openIssuesCount ? _self.openIssuesCount : openIssuesCount // ignore: cast_nullable_to_non_nullable

--- a/lib/features/repository_search/domain/entity/repository.g.dart
+++ b/lib/features/repository_search/domain/entity/repository.g.dart
@@ -8,6 +8,8 @@ part of 'repository.dart';
 
 _Repository _$RepositoryFromJson(Map<String, dynamic> json) => _Repository(
   name: json['name'] as String,
+  fullName: json['full_name'] as String,
+  id: (json['id'] as num).toInt(),
   stargazersCount: (json['stargazers_count'] as num).toInt(),
   watchersCount: (json['watchers_count'] as num).toInt(),
   forksCount: (json['forks_count'] as num).toInt(),
@@ -22,6 +24,8 @@ _Repository _$RepositoryFromJson(Map<String, dynamic> json) => _Repository(
 Map<String, dynamic> _$RepositoryToJson(_Repository instance) =>
     <String, dynamic>{
       'name': instance.name,
+      'full_name': instance.fullName,
+      'id': instance.id,
       'stargazers_count': instance.stargazersCount,
       'watchers_count': instance.watchersCount,
       'forks_count': instance.forksCount,

--- a/lib/features/repository_search/presentation/page/repository_details/widget/repository_details_card.dart
+++ b/lib/features/repository_search/presentation/page/repository_details/widget/repository_details_card.dart
@@ -133,7 +133,7 @@ class _RepositoryDetailsCardState extends State<RepositoryDetailsCard>
     return Center(
       child: Hero(
         transitionOnUserGestures: true,
-        tag: 'repository-${widget.repository.name}',
+        tag: 'repository-${widget.repository.id}-${widget.repository.fullName}',
         flightShuttleBuilder: _heroAnimationBuilder.buildFlightShuttle,
         child: AnimatedBuilder(
           animation: _animationState,

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
@@ -163,7 +163,7 @@ class _SearchResultListItem extends StatelessWidget {
       // ヒーローアニメーションを使用してリポジトリのリストを表示
       // 詳細画面のHeroと同一のタグを使用することでアニメーションを実現している
       transitionOnUserGestures: true,
-      tag: 'repository-${repository.name}',
+      tag: 'repository-${repository.id}-${repository.fullName}',
 
       child: Card(
         // カードの影の深さ

--- a/test/features/repository_search/domain/entitiy/repository_test.dart
+++ b/test/features/repository_search/domain/entitiy/repository_test.dart
@@ -6,6 +6,8 @@ void main() {
   group('GitHubリポジトリ検索APIのモデルに関するテスト', () {
     const response = Repository(
       name: 'flutter',
+      fullName: 'flutter/flutter',
+      id: 123456,
       owner: Owner(
         avatarUrl: 'https://avatars.githubusercontent.com/u/14101776?v=4',
       ),
@@ -18,6 +20,8 @@ void main() {
 
     final json = {
       'name': 'flutter',
+      'full_name': 'flutter/flutter',
+      'id': 123456,
       'owner': {
         'avatar_url': 'https://avatars.githubusercontent.com/u/14101776?v=4',
       },
@@ -44,6 +48,8 @@ void main() {
       final response = Repository.fromJson(json);
 
       expect(response.name, 'flutter');
+      expect(response.fullName, 'flutter/flutter');
+      expect(response.id, 123456);
       expect(response.owner, isNotNull);
       expect(
         response.owner!.avatarUrl,
@@ -74,6 +80,8 @@ void main() {
     test('ownerがnullでもパースできる', () {
       final json = {
         'name': 'test-repo',
+        'full_name': 'test-repo/test-repo',
+        'id': 1,
         'owner': null,
         'language': 'Dart',
         'stargazers_count': 10,
@@ -94,6 +102,8 @@ void main() {
     test('languageがnullでもパースできる', () {
       final json = {
         'name': 'test-repo',
+        'full_name': 'test-repo/test-repo',
+        'id': 1,
         'owner': null,
         'language': null,
         'stargazers_count': 10,
@@ -103,6 +113,8 @@ void main() {
       };
       final repo = Repository.fromJson(json);
       expect(repo.name, 'test-repo');
+      expect(repo.fullName, 'test-repo/test-repo');
+      expect(repo.id, 1);
       expect(repo.owner, isNull);
       expect(repo.language, isNull);
       expect(repo.stargazersCount, 10);
@@ -114,6 +126,8 @@ void main() {
     test('toJsonでownerがnullの場合も正しく出力される', () {
       const repo = Repository(
         name: 'test-repo',
+        fullName: 'test-repo/test-repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 10,
         watchersCount: 10,
@@ -133,6 +147,8 @@ void main() {
     test('toJsonでlanguageがnullの場合も正しく出力される', () {
       const repo = Repository(
         name: 'test-repo',
+        fullName: 'test-repo/test-repo',
+        id: 1,
         stargazersCount: 10,
         watchersCount: 10,
         forksCount: 1,

--- a/test/features/repository_search/presentation/common/widget/owner_icon_test.dart
+++ b/test/features/repository_search/presentation/common/widget/owner_icon_test.dart
@@ -11,6 +11,8 @@ void main() {
     testWidgets('オーナーがnullの場合、デフォルトアイコンが表示される', (tester) async {
       const repository = Repository(
         name: 'repo',
+        fullName: 'repo/repo',
+        id: 1,
         stargazersCount: 0,
         watchersCount: 0,
         forksCount: 0,
@@ -27,6 +29,8 @@ void main() {
     testWidgets('オーナーのavatarUrlが空文字の場合、デフォルトアイコンが表示される', (tester) async {
       const repository = Repository(
         name: 'repo',
+        fullName: 'repo/repo',
+        id: 1,
         stargazersCount: 0,
         watchersCount: 0,
         forksCount: 0,
@@ -44,6 +48,8 @@ void main() {
     testWidgets('オーナーのavatarUrlが有効な場合、Image.networkが表示される', (tester) async {
       const repository = Repository(
         name: 'repo',
+        fullName: 'repo/repo',
+        id: 1,
         stargazersCount: 0,
         watchersCount: 0,
         forksCount: 0,

--- a/test/features/repository_search/presentation/page/repository_details/repository_details_page_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/repository_details_page_test.dart
@@ -14,6 +14,8 @@ void main() {
     testWidgets('AppBarタイトルと戻るボタン、RepositoryDetailsCardが表示される', (tester) async {
       const repository = Repository(
         name: 'test_repo',
+        fullName: 'test_repo/test_repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 10,
         watchersCount: 5,
@@ -49,6 +51,8 @@ void main() {
           // Given: 詳細なリポジトリ情報
           const repository = Repository(
             name: 'flutter-samples',
+            fullName: 'flutter/flutter-samples',
+            id: 123456,
             language: 'Dart',
             stargazersCount: 15000,
             watchersCount: 1000,
@@ -108,6 +112,8 @@ void main() {
           // Given: リポジトリ詳細画面が表示されている
           const repository = Repository(
             name: 'test-repo',
+            fullName: 'test-repo/test-repo',
+            id: 1,
             language: 'JavaScript',
             stargazersCount: 100,
             watchersCount: 50,
@@ -140,6 +146,8 @@ void main() {
           // Given: 最小限の情報を持つリポジトリ
           const minimalRepository = Repository(
             name: 'minimal-repo',
+            fullName: 'minimal-repo/minimal-repo',
+            id: 999999,
             // 言語は null
             stargazersCount: 0,
             watchersCount: 0,

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder_test.dart
@@ -14,6 +14,8 @@ void main() {
         // Given: 豊富な情報を持つリポジトリ
         const repository = Repository(
           name: 'awesome-flutter-app',
+          fullName: 'flutter/awesome-flutter-app',
+          id: 123456,
           language: 'Dart',
           stargazersCount: 25000,
           watchersCount: 1500,
@@ -69,6 +71,8 @@ void main() {
         // Given: 同じリポジトリデータで異なるアニメーション状態
         const repository = Repository(
           name: 'animation-test-repo',
+          fullName: 'flutter/animation-test-repo',
+          id: 789012,
           language: 'JavaScript',
           stargazersCount: 1000,
           watchersCount: 100,
@@ -113,6 +117,8 @@ void main() {
         // Given: 最小限のリポジトリ情報
         const minimalRepository = Repository(
           name: 'minimal-info-repo',
+          fullName: 'minimal/minimal-info-repo',
+          id: 999999,
           // language, ownerは null
           stargazersCount: 0,
           watchersCount: 0,
@@ -152,6 +158,8 @@ void main() {
       // Given: UIビルダーとアニメーションオブジェクト
       const repository = Repository(
         name: 'decoration-test',
+        fullName: 'flutter/decoration-test',
+        id: 1234567,
         stargazersCount: 100,
         watchersCount: 50,
         forksCount: 25,

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_details_card_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_details_card_test.dart
@@ -11,6 +11,8 @@ void main() {
     testWidgets('リポジトリ情報が正しく表示される', (tester) async {
       const repository = Repository(
         name: 'test_repo',
+        fullName: 'test_repo/test_repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 10,
         watchersCount: 5,
@@ -46,6 +48,8 @@ void main() {
     testWidgets('オーナー情報がnullの場合はデフォルトアイコンが表示される', (tester) async {
       const repository = Repository(
         name: 'test_repo',
+        fullName: 'test_repo/test_repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 10,
         watchersCount: 5,
@@ -63,6 +67,8 @@ void main() {
     testWidgets('オーナー情報のavatarUrlが空の場合もデフォルトアイコンが表示される', (tester) async {
       const repository = Repository(
         name: 'test_repo',
+        fullName: 'test_repo/test_repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 10,
         watchersCount: 5,
@@ -81,6 +87,8 @@ void main() {
     testWidgets('スター数などが大きい場合はNumberFormatで省略表示される', (tester) async {
       const repository = Repository(
         name: 'test_repo',
+        fullName: 'test_repo/test_repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 12345,
         watchersCount: 67890,
@@ -99,6 +107,8 @@ void main() {
     testWidgets('画面幅600以上で横レイアウト、未満で縦レイアウト', (tester) async {
       const repository = Repository(
         name: 'test_repo',
+        fullName: 'test_repo/test_repo',
+        id: 1,
         language: 'Dart',
         stargazersCount: 10,
         watchersCount: 5,

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_test.dart
@@ -15,6 +15,8 @@ void main() {
         // Given: ユーザーがリポジトリ検索結果を見ている
         const testRepository = Repository(
           name: 'flutter',
+          fullName: 'flutter/flutter',
+          id: 123456,
           language: 'Dart',
           stargazersCount: 100000,
           watchersCount: 5000,
@@ -88,9 +90,12 @@ void main() {
       'リポジトリ名が同じならば同一のHeroタグが使用され、アニメーションが実行される',
       (tester) async {
         // Given: 同じ名前のリポジトリが2つの画面に存在する
-        const repositoryName = 'awesome-repo';
+        const repositoryFullName = 'awesome/awesome-repo';
+        const id = 789012;
         const testRepository = Repository(
-          name: repositoryName,
+          name: 'awesome-repo',
+          fullName: repositoryFullName,
+          id: id,
           language: 'JavaScript',
           stargazersCount: 42,
           watchersCount: 12,
@@ -112,7 +117,7 @@ void main() {
 
         // Then: 適切なタグを持つHeroウィジェットが存在する
         final listHero = tester.widget<Hero>(find.byType(Hero));
-        expect(listHero.tag, equals('repository-$repositoryName'));
+        expect(listHero.tag, equals('repository-$id-$repositoryFullName'));
 
         // When: 詳細画面のHeroウィジェットを確認
         await pumpAppWithLocale(
@@ -125,7 +130,7 @@ void main() {
 
         // Then: 同じタグを持つHeroウィジェットが存在する
         final detailHero = tester.widget<Hero>(find.byType(Hero));
-        expect(detailHero.tag, equals('repository-$repositoryName'));
+        expect(detailHero.tag, equals('repository-$id-$repositoryFullName'));
         expect(detailHero.tag, equals(listHero.tag));
       },
     );
@@ -136,6 +141,8 @@ void main() {
         // Given: ユーザージェスチャーに対応したHeroアニメーション設定
         const testRepository = Repository(
           name: 'gesture-test-repo',
+          fullName: 'test/gesture-test-repo',
+          id: 654321,
           language: 'Swift',
           stargazersCount: 777,
           watchersCount: 111,
@@ -180,6 +187,8 @@ void main() {
         // Given: 最小限の情報しか持たないリポジトリ
         const minimalRepository = Repository(
           name: 'minimal-repo',
+          fullName: 'minimal/minimal-repo',
+          id: 999999,
           stargazersCount: 0,
           watchersCount: 0,
           forksCount: 0,
@@ -211,6 +220,8 @@ void main() {
         // Given: Hero アニメーションを持つリポジトリ詳細カード
         const testRepository = Repository(
           name: 'animation-test',
+          fullName: 'test/animation-test',
+          id: 1234567,
           language: 'Flutter',
           stargazersCount: 1000,
           watchersCount: 500,
@@ -241,6 +252,8 @@ void main() {
         // Given: アニメーション性能を測定するためのリポジトリ
         const testRepository = Repository(
           name: 'performance-test',
+          fullName: 'test/performance-test',
+          id: 987654,
           language: 'Dart',
           stargazersCount: 50000,
           watchersCount: 10000,
@@ -284,6 +297,8 @@ void main() {
         // Given: アクセシビリティ設定でアニメーション無効
         const testRepository = Repository(
           name: 'accessibility-test',
+          fullName: 'test/accessibility-test',
+          id: 112233,
           language: 'Python',
           stargazersCount: 123,
           watchersCount: 45,

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_layout_strategy_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_layout_strategy_test.dart
@@ -13,6 +13,8 @@ void main() {
         // Given: 表示するリポジトリ情報
         const repository = Repository(
           name: 'layout-test-repo',
+          fullName: 'test/layout-test-repo',
+          id: 1,
           language: 'TypeScript',
           stargazersCount: 5000,
           watchersCount: 500,
@@ -63,6 +65,8 @@ void main() {
         // Given: アニメーション進行中のシナリオ
         const repository = Repository(
           name: 'animation-layout-test',
+          fullName: 'test/animation-layout-test',
+          id: 2,
           language: 'Go',
           stargazersCount: 2000,
           watchersCount: 200,
@@ -110,6 +114,8 @@ void main() {
         // Given: テスト用リポジトリ
         const repository = Repository(
           name: 'responsive-test',
+          fullName: 'test/responsive-test',
+          id: 3,
           language: 'Python',
           stargazersCount: 15000,
           watchersCount: 1000,
@@ -161,6 +167,8 @@ void main() {
         // Given: ファクトリーメソッドのテスト
         const repository = Repository(
           name: 'factory-pattern-test',
+          fullName: 'test/factory-pattern-test',
+          id: 4,
           language: 'Rust',
           stargazersCount: 3000,
           watchersCount: 300,

--- a/test/features/repository_search/presentation/page/repository_search/widget/search_result_list_view_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/search_result_list_view_test.dart
@@ -17,6 +17,8 @@ void main() {
       final dummyList = [
         const Repository(
           name: 'repo1',
+          fullName: 'user/repo1',
+          id: 1,
           stargazersCount: 10,
           watchersCount: 5,
           forksCount: 2,
@@ -24,6 +26,8 @@ void main() {
         ),
         const Repository(
           name: 'repo2',
+          fullName: 'user/repo2',
+          id: 2,
           stargazersCount: 20,
           watchersCount: 10,
           forksCount: 4,


### PR DESCRIPTION
## 概要

リポジトリ名の重複によるHeroアニメーションの不具合を解消するため、　　
Heroタグを `repository.id` と `repository.fullName` の組み合わせに変更し、　　
関連するエンティティ・UI・生成ファイルを修正しました。

## 関連Issue

#70 

## 変更内容

### 主な内容

- `Repository`エンティティに `id` および `fullName` プロパティを追加
  - `lib/features/repository_search/domain/entity/repository.dart`
  - `lib/features/repository_search/domain/entity/repository.freezed.dart`
  - `lib/features/repository_search/domain/entity/repository.g.dart`

- Heroアニメーションのタグを `repository.id` と `repository.fullName` の組み合わせに変更
  - `lib/features/repository_search/presentation/page/repository_details/widget/repository_details_card.dart`
  - `lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart`

- その他テストの追従

## 動作確認内容

`react`などの衝突する文字列で検索しても Hero によるアニメーションが動作すること

| before | after |
| - | - |
| Heroのアニメーションが適用されてない | Heroのアニメーションが適用されている |
|  ![before](https://github.com/user-attachments/assets/c148cbdd-dd63-44c8-97d4-b9dabab8c6a5) | ![after](https://github.com/user-attachments/assets/cfb56aff-3a77-487a-9e54-3e40703fd6f6) |

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください