### PR TITLE
Feature/not serched view

### DIFF
--- a/.github/prompts/add_wording.prompt.md
+++ b/.github/prompts/add_wording.prompt.md
@@ -1,0 +1,36 @@
+---
+mode: agent
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+---
+入力された文言についての翻訳文言の整備をお願いします。
+翻訳文言の整備は以下の手順に従って下さい。
+
+### 1. まずは基本的な翻訳文言の追加をお願いします。
+
+翻訳文言の追加方法は documents/how-to-add-strings.md を参照してください。
+
+### 2. 英語文言のWordingDataクラスへの追加
+
+英語文言は、`lib/l10n/app_localizations*.dart` に追加されます。
+この中で変更のあった箇所を、 `lib/static/wording_data.dart` の `WordingData` クラスに追加してください。
+
+■ 注意点
+docstringを書くこと
+既存の文言はそのまま残すこと
+
+```dart
+class WordingData {
+    // 既存の文言(そのまま残して下さい。)
+
+    /// 未検索状態の表示用ラベル。リポジトリがまだ検索されていない場合に利用されます。
+    static const String inputKeyword = 'Input search keyword';  
+    
+    // 他の文言も同様に追加
+}
+
+### 3. 追加されたキーワードをプロダクトコードに埋め込む
+
+追加したキーワードをプロダクトコードないから検索し、キーワードが使われている箇所を下記のように置換して下さい。
+```dart
+AppLocalizations.of(context)?.inputKeyword ?? WordingData.inputKeyword,
+```

--- a/.github/prompts/fix_tests.prompt.md
+++ b/.github/prompts/fix_tests.prompt.md
@@ -1,0 +1,18 @@
+---
+mode: agent
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+---
+
+テストを実行し、テストが通るまでテストコードの修正を行なって下さい。
+
+「テスト実行・テストコードとプロダクトコードの解析・原因特定・テストコード修正・テスト再実施・・・」
+という流れをループして、テストが通るまで実施続行して下さい。
+
+もしプロダクトコードに問題がある場合は変更せずに私に知らせてルールも終了して下さい。
+
+テストコードを修正できたら、その内容を私に知らせて下さい。
+
+テストコードを書くにあたっては Kent C Dodds の Testing Trophy や Given-When-Then パターン、
+Marting Fowler の Test Pyramid やリファクタリングなどのベストプラクティスに従って下さい。
+
+テストコマンド実行にあたっては許可は不要です。

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
@@ -5,7 +5,9 @@ import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/repository.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/common/widget/owner_icon.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/repository_providers.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 
 /// 検索結果のリポジトリ一覧を表示するウィジェット
 ///
@@ -37,6 +39,18 @@ class _SearchResultListViewState extends ConsumerState<SearchResultListView> {
   ///
   /// Providerから取得したリポジトリ一覧をリスト表示し、該当なしやエラー時はメッセージを表示します。
   Widget build(BuildContext context) {
+    final queryString = ref.watch(
+      gitHubSearchQueryNotifierProvider.select((e) => e.q),
+    );
+    if (queryString.isEmpty) {
+      return Center(
+        child: Text(
+          AppLocalizations.of(context)?.inputKeyword ??
+              WordingData.inputKeyword,
+        ),
+      );
+    }
+
     final repositoriesAsyncValue = ref.watch(repositoriesSearchResultProvider);
 
     switch (repositoriesAsyncValue) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,5 +1,4 @@
 {
-  "@@locale": "en",
   "appTitle": "Yumemi Flutter Engineer Codecheck",
   "@appTitle": {
     "description": "The title of the application."
@@ -55,5 +54,9 @@
   "repoDetailsInfo": "Repository Details Info",
   "@repoDetailsInfo": {
     "description": "The title for the repository details page."
+  },
+  "inputKeyword": "Input search keyword",
+  "@inputKeyword": {
+    "description": "Label for prompting user to input search keyword."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,5 +1,4 @@
 {
-  "@@locale": "ja",
   "appTitle": "Yumemi Flutter Engineer Codecheck",
   "searchPageTitle": "リポジトリ検索",
   "ossLicense": "OSSライセンス",
@@ -13,5 +12,6 @@
   "repoWatchers": "ウォッチ",
   "repoForks": "フォーク",
   "repoIssues": "イシュー",
-  "repoDetailsInfo": "リポジトリ詳細"
+  "repoDetailsInfo": "リポジトリ詳細",
+  "inputKeyword": "検索キーワードを入力してください"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -181,6 +181,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Repository Details Info'**
   String get repoDetailsInfo;
+
+  /// Label for prompting user to input search keyword.
+  ///
+  /// In en, this message translates to:
+  /// **'Input search keyword'**
+  String get inputKeyword;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -49,4 +49,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get repoDetailsInfo => 'Repository Details Info';
+
+  @override
+  String get inputKeyword => 'Input search keyword';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -49,4 +49,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get repoDetailsInfo => 'リポジトリ詳細';
+
+  @override
+  String get inputKeyword => '検索キーワードを入力してください';
 }

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -13,3 +13,4 @@ repoWatchers,The number of watchers of the repository.,Watchers,ウォッチ
 repoForks,The number of forks of the repository.,Forks,フォーク
 repoIssues,The number of open issues of the repository.,Issues,イシュー
 repoDetailsInfo,The title for the repository details page.,Repository Details Info,リポジトリ詳細
+inputKeyword,Label for prompting user to input search keyword.,Input search keyword,検索キーワードを入力してください

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -49,4 +49,7 @@ class WordingData {
 
   /// リポジトリ詳細情報の見出し。詳細画面のセクションタイトルなどで利用されます。
   static const repoDetailsInfo = 'Repository Details Info';
+
+  /// 未検索状態の表示用ラベル。リポジトリがまだ検索されていない場合に利用されます。
+  static const inputKeyword = 'Input search keyword';
 }

--- a/test/features/repository_search/presentation/page/repository_search/widget/search_result_list_view_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/search_result_list_view_test.dart
@@ -5,11 +5,19 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/git_hub_search_query.dart'
+    as entity;
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/repository.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/repository_search_page.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/repository_providers.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+
+class _TestGitHubSearchQueryNotifier extends GitHubSearchQueryNotifier {
+  @override
+  entity.GitHubSearchQuery build() =>
+      const entity.GitHubSearchQuery(q: 'flutter');
+}
 
 void main() {
   group('SearchResultListView UIテスト', () {
@@ -37,6 +45,9 @@ void main() {
       await tester.pumpWidget(
         _buildTestWidget(
           repositoriesSearchResultProvider.overrideWith((_) => dummyList),
+          gitHubSearchQueryNotifierProvider.overrideWith(
+            _TestGitHubSearchQueryNotifier.new,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -47,8 +58,9 @@ void main() {
     testWidgets('空リスト時にメッセージが表示される', (tester) async {
       await tester.pumpWidget(
         _buildTestWidget(
-          repositoriesSearchResultProvider.overrideWith(
-            (_) => <Repository>[],
+          repositoriesSearchResultProvider.overrideWith((_) => <Repository>[]),
+          gitHubSearchQueryNotifierProvider.overrideWith(
+            _TestGitHubSearchQueryNotifier.new,
           ),
         ),
       );
@@ -63,6 +75,9 @@ void main() {
           repositoriesSearchResultProvider.overrideWith(
             (_) => completer.future,
           ),
+          gitHubSearchQueryNotifierProvider.overrideWith(
+            _TestGitHubSearchQueryNotifier.new,
+          ),
         ),
       );
       await tester.pump();
@@ -75,6 +90,9 @@ void main() {
         _buildTestWidget(
           repositoriesSearchResultProvider.overrideWith(
             (_) => throw Exception('error'),
+          ),
+          gitHubSearchQueryNotifierProvider.overrideWith(
+            _TestGitHubSearchQueryNotifier.new,
           ),
         ),
       );
@@ -138,9 +156,9 @@ void main() {
   });
 }
 
-Widget _buildTestWidget(Override override) {
+Widget _buildTestWidget(Override override1, [Override? override2]) {
   return ProviderScope(
-    overrides: [override],
+    overrides: override2 != null ? [override1, override2] : [override1],
     child: const MaterialApp(
       localizationsDelegates: [
         AppLocalizations.delegate,


### PR DESCRIPTION
## 概要

リポジトリ検索画面の検索結果リスト表示に「未検索時のビュー」を追加し、関連する文言やローカライズデータ、テストコードを拡充しました。

## 関連Issue

#83 

## 変更内容

### 主な内容

- 「未検索時のビュー」追加
  - lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart

- 文言・ローカライズデータの追加・修正
  - lib/l10n/app_en.arb
  - lib/l10n/app_ja.arb
  - lib/l10n/app_localizations.dart
  - lib/l10n/app_localizations_en.dart
  - lib/l10n/app_localizations_ja.dart
  - lib/l10n/strings.csv
  - lib/static/wording_data.dart

- テストコードの追加・修正
  - test/features/repository_search/presentation/page/repository_search/widget/search_result_list_view_test.dart

- プロンプトファイルの追加・修正
  - .github/prompts/add_wording.prompt.md
  - .github/prompts/fix_tests.prompt.md

## 動作確認内容

下記のような検索文字列が０文字になる状況で正しい文言が表示されるか確認した。
- アプリ立ち上げ直後
- 入力して、すべて削除した後
- 入力して [×] ボタンを押した後

## 補足
