### PR TITLE
Hero/Cardに関わる見た目の修正を行なった

### DIFF
--- a/lib/features/repository_search/presentation/common/widget/common_repository_card.dart
+++ b/lib/features/repository_search/presentation/common/widget/common_repository_card.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/common/widget/owner_icon.dart';
+
+/// 共通のリポジトリカードウィジェット。
+///
+/// リポジトリ情報をカード形式で表示するための汎用ウィジェットです。
+/// ListTile形式またはカスタムchildを選択でき、リスト表示や詳細表示など様々な場面で利用できます。
+class CommonRepositoryCard extends StatelessWidget {
+  /// [repository]の情報を表示するカードを生成します。
+  ///
+  /// [repository]は表示対象のリポジトリ情報、[onTap]はタップ時のコールバック、
+  /// [borderRadius]はカードの角丸、[margin]は外側余白、[showChevron]は右端の矢印アイコン表示、
+  /// [useListTile]はListTile形式で表示するか、[child]はカスタムウィジェットを指定します。
+  const CommonRepositoryCard({
+    required this.repository,
+    super.key,
+    this.onTap,
+    this.borderRadius = 16,
+    this.margin = const EdgeInsets.all(8),
+    this.showChevron = false,
+    this.useListTile = true,
+    this.child,
+  });
+
+  /// 表示対象のリポジトリ情報。
+  final Repository repository;
+
+  /// カードタップ時のコールバック。
+  final VoidCallback? onTap;
+
+  /// カードの角丸半径。
+  final double borderRadius;
+
+  /// カード外側の余白。
+  final EdgeInsetsGeometry margin;
+
+  /// 右端に矢印アイコンを表示するかどうか。
+  final bool showChevron;
+
+  /// ListTile形式で表示するかどうか。
+  final bool useListTile;
+
+  /// ListTileを使わずカスタムchildを表示したい場合に指定。
+  final Widget? child;
+
+  /// カードのウィジェットツリーを構築します。
+  ///
+  /// ListTile形式またはchildで内容を切り替えます。
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(borderRadius),
+      ),
+      margin: margin,
+      child:
+          useListTile
+              ? ListTile(
+                leading: OwnerIcon(repository: repository, diameter: 20),
+                title: Text(
+                  repository.name,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                trailing: showChevron ? const Icon(Icons.chevron_right) : null,
+                onTap: onTap,
+              )
+              : child,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Repository>('repository', repository));
+    properties.add(ObjectFlagProperty<VoidCallback?>.has('onTap', onTap));
+    properties.add(DoubleProperty('borderRadius', borderRadius));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin));
+    properties.add(DiagnosticsProperty<bool>('showChevron', showChevron));
+    properties.add(DiagnosticsProperty<bool>('useListTile', useListTile));
+  }
+}

--- a/lib/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder.dart
+++ b/lib/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/repository.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/common/widget/common_repository_card.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_details/widget/repository_layout_strategy.dart';
 
 /// リポジトリ詳細カードのUI構築を担うユーティリティ。
@@ -32,11 +33,19 @@ class RepositoryCardUIBuilder {
   /// リポジトリ情報をカード形式で表示し、アニメーション状態に応じて見た目を調整します。
   Widget buildCardContent(BuildContext context) {
     return SizedBox.expand(
-      child: Card(
-        margin: const EdgeInsets.all(8),
-        shape: _buildCardShape(),
-        color: _determineCardColor(context),
-        child: _buildCardBody(),
+      child: CommonRepositoryCard(
+        repository: repository,
+        useListTile: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+          child: SingleChildScrollView(
+            child: _RepositoryInfo(
+              repository: repository,
+              isHeroAnimationCompleted: isHeroAnimationCompleted,
+              isHeroAnimationInProgress: isHeroAnimationInProgress,
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -54,41 +63,6 @@ class RepositoryCardUIBuilder {
           spreadRadius: 2 * animation.value,
         ),
       ],
-    );
-  }
-
-  /// カードの角丸形状を返します。
-  ///
-  /// デザイン統一のため、角丸は16pxで固定です。
-  RoundedRectangleBorder _buildCardShape() {
-    return RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(16),
-    );
-  }
-
-  /// アニメーション状態に応じてカードの色を決定します。
-  ///
-  /// アニメーション進行中は透明度を下げて強調を抑えます。
-  Color _determineCardColor(BuildContext context) {
-    final cardColor = Theme.of(context).cardColor;
-    return isHeroAnimationCompleted
-        ? cardColor
-        : cardColor.withAlpha((255 * 0.8).round());
-  }
-
-  /// カード内部の本体ウィジェットを構築します。
-  ///
-  /// パディングやスクロール対応、リポジトリ情報表示ウィジェットを内包します。
-  Widget _buildCardBody() {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
-      child: SingleChildScrollView(
-        child: _RepositoryInfo(
-          repository: repository,
-          isHeroAnimationCompleted: isHeroAnimationCompleted,
-          isHeroAnimationInProgress: isHeroAnimationInProgress,
-        ),
-      ),
     );
   }
 }

--- a/lib/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder.dart
+++ b/lib/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder.dart
@@ -54,13 +54,21 @@ class RepositoryCardUIBuilder {
   ///
   /// Heroアニメーションの進行度に応じて影や透明度を動的に変化させます。
   BoxDecoration buildAnimationDecoration(Animation<double> animation) {
+    // アニメーション中は影を消す（animation.value <= 1.0）
+    if (animation.value <= 1.0) {
+      return BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: const [],
+      );
+    }
+    // アニメーション完了時のみ影を付与
     return BoxDecoration(
       borderRadius: BorderRadius.circular(16),
       boxShadow: [
         BoxShadow(
-          color: Colors.black.withValues(alpha: 0.3 * animation.value),
-          blurRadius: 10 * animation.value,
-          spreadRadius: 2 * animation.value,
+          color: Colors.black.withValues(alpha: 0.3),
+          blurRadius: 10,
+          spreadRadius: 2,
         ),
       ],
     );

--- a/lib/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_builder.dart
+++ b/lib/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_builder.dart
@@ -84,8 +84,8 @@ class RepositoryHeroAnimationBuilder {
     // 遷移方向に応じたスケール効果
     final scaleValue =
         direction == HeroFlightDirection.push
-            ? 0.98 + (0.04 * curvedValue)
-            : 1.02 - (0.04 * curvedValue);
+            ? 0.96 + (0.04 * curvedValue)
+            : 1.04 - (0.04 * curvedValue);
 
     return Transform.scale(
       scale: scaleValue,

--- a/lib/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_builder.dart
+++ b/lib/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_builder.dart
@@ -85,7 +85,7 @@ class RepositoryHeroAnimationBuilder {
     final scaleValue =
         direction == HeroFlightDirection.push
             ? 0.96 + (0.04 * curvedValue)
-            : 1.04 - (0.04 * curvedValue);
+            : 1.00 - (0.04 * curvedValue);
 
     return Transform.scale(
       scale: scaleValue,

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/repository.dart';
-import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/common/widget/owner_icon.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/common/widget/common_repository_card.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/repository_providers.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
@@ -179,28 +179,14 @@ class _SearchResultListItem extends StatelessWidget {
       transitionOnUserGestures: true,
       tag: 'repository-${repository.id}-${repository.fullName}',
 
-      child: Card(
-        // カードの影の深さ
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: CommonRepositoryCard(
+        repository: repository,
+        borderRadius: 8,
         margin: const EdgeInsets.symmetric(vertical: 6),
-        child: ListTile(
-          leading: OwnerIcon(repository: repository, diameter: 20),
-          title: Text(
-            repository.name,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-          trailing: const Icon(Icons.chevron_right),
-
-          onTap: () async {
-            await GoRouter.of(
-              context,
-            ).pushNamed('details', extra: repository);
-          },
-        ),
+        showChevron: true,
+        onTap: () async {
+          await GoRouter.of(context).pushNamed('details', extra: repository);
+        },
       ),
     );
   }

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder_test.dart
@@ -203,7 +203,7 @@ void main() {
         reason: 'アニメーション完了時はシャドウ効果が設定されるべき',
       );
       expect(
-        decorationCompleted.boxShadow!.first.color.alpha,
+        decorationCompleted.boxShadow!.first.color.a,
         greaterThan(0),
         reason: 'シャドウに透明度が設定されるべき',
       );

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_card_ui_builder_test.dart
@@ -172,21 +172,38 @@ void main() {
         isHeroAnimationInProgress: true,
       );
 
-      // Mock Animation
-      const mockAnimation = AlwaysStoppedAnimation<double>(0.5);
+      // When: アニメーション進行中（animation.value <= 1.0）
+      const mockAnimationInProgress = AlwaysStoppedAnimation<double>(0.5);
+      final decorationInProgress = uiBuilder.buildAnimationDecoration(
+        mockAnimationInProgress,
+      );
 
-      // When: アニメーション装飾を構築
-      final decoration = uiBuilder.buildAnimationDecoration(mockAnimation);
-
-      // Then: 適切な装飾設定が生成される
+      // Then: シャドウは付与されない
       expect(
-        decoration.borderRadius,
+        decorationInProgress.boxShadow,
+        isEmpty,
+        reason: 'アニメーション中はシャドウが消えるべき',
+      );
+
+      // When: アニメーション完了（animation.value > 1.0）
+      const mockAnimationCompleted = AlwaysStoppedAnimation<double>(1.1);
+      final decorationCompleted = uiBuilder.buildAnimationDecoration(
+        mockAnimationCompleted,
+      );
+
+      // Then: シャドウが付与される
+      expect(
+        decorationCompleted.borderRadius,
         equals(BorderRadius.circular(16)),
         reason: '角丸16pxが設定されるべき',
       );
-      expect(decoration.boxShadow, isNotEmpty, reason: 'シャドウ効果が設定されるべき');
       expect(
-        decoration.boxShadow!.first.color.a,
+        decorationCompleted.boxShadow,
+        isNotEmpty,
+        reason: 'アニメーション完了時はシャドウ効果が設定されるべき',
+      );
+      expect(
+        decorationCompleted.boxShadow!.first.color.alpha,
         greaterThan(0),
         reason: 'シャドウに透明度が設定されるべき',
       );


### PR DESCRIPTION
## 概要

アニメーション完了前後のウィジェットサイズのズレを修正した

## 関連Issue

#85 
#86 

## 変更内容

- Cardウィジェットを共通化した
- 画面遷移アニメーション最中のウィジェットの影を削除した
- 画面遷移アニメーションの拡大縮小率が遷移後のウィジェットサイズに合うようにになってなかったのでちょうどよくなるように修正

## 動作確認内容

下記の環境を組み合わせて画面遷移時の見た目の違和感がないか確認した
テーマモード：ライトモード・ダークモード
デバイス：iPhone SE 3rf, iPad mini 6th, Chrome(全画面)

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->
