### PR TITLE
Feature/search history

### DIFF
--- a/.github/prompts/add_wording.prompt.md
+++ b/.github/prompts/add_wording.prompt.md
@@ -5,9 +5,9 @@ tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFile
 入力された文言についての翻訳文言の整備をお願いします。
 翻訳文言の整備は以下の手順に従って下さい。
 
-### 1. まずは基本的な翻訳文言の追加をお願いします。
+### 1. 基本的な翻訳文言の追加
 
-翻訳文言の追加方法は documents/how-to-add-strings.md を参照してください。
+翻訳文言の追加方法は documents/how-to-add-strings.md を参照しその内容に従って文言を追加して下さい。
 
 ### 2. 英語文言のWordingDataクラスへの追加
 

--- a/lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
@@ -52,28 +52,18 @@ class _SearchPageState extends ConsumerState<RepositorySearchPage> {
                 ),
                 child: SearchTextField(
                   controller: controller,
-                  onChanged: (value) {
-                    ref
-                        .read(gitHubSearchQueryNotifierProvider.notifier)
-                        .setQuery(q: value);
-                  },
-                  onSubmitted: (value) {
-                    ref
-                        .read(gitHubSearchQueryNotifierProvider.notifier)
-                        .setQuery(q: value);
-                  },
+                  onChanged: _setQuery,
+                  onSubmitted: _setQuery,
                   onCancelButtonPressed: () {
                     setState(controller.clear);
-                    ref
-                        .read(gitHubSearchQueryNotifierProvider.notifier)
-                        .setQuery(q: '');
+                    _setQuery('');
                   },
                   labelText:
                       AppLocalizations.of(context)?.searchRepositories ??
                       WordingData.searchRepositories,
                 ),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: NumberData.paddingSmall),
               const Expanded(
                 child: SearchResultListView(),
               ),
@@ -83,6 +73,9 @@ class _SearchPageState extends ConsumerState<RepositorySearchPage> {
       ),
     );
   }
+
+  void _setQuery(String value) =>
+      ref.read(gitHubSearchQueryNotifierProvider.notifier).setQuery(q: value);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
@@ -42,7 +42,12 @@ class _SearchPageState extends ConsumerState<RepositorySearchPage> {
                 WordingData.searchPageTitle,
           ),
         ),
-        drawer: const CustomDrawer(),
+        drawer: CustomDrawer(
+          onHistoryTap: (value) {
+            controller.text = value;
+            _setQuery(value);
+          },
+        ),
         body: Center(
           child: Column(
             children: [

--- a/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
@@ -289,7 +289,7 @@ class _ApplyTestDataButton extends ConsumerWidget {
           'freezed',
           'json serialization',
           'yumemi flutter engineer codecheck',
-          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
         ];
         await ref.read(searchHistoryProvider.notifier).clear();
         for (final s in searchHistories) {

--- a/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
@@ -1,39 +1,302 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/show_oss_license_button.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/theme_mode_select_button.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/search_history_provider.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 
-/// アプリケーションのカスタムドロワーメニューを表示するウィジェット
+/// 検索履歴やテーマ切り替えなどを含むカスタムドロワーウィジェット。
 ///
-/// テーマ切り替えやOSSライセンス表示などのメニュー項目を含みます。
+/// 検索履歴のリスト表示やテーマモードの切り替え、OSSライセンス表示ボタンを含みます。
 class CustomDrawer extends ConsumerWidget {
-  /// カスタムドロワーのコンストラクタ
+  /// 検索履歴の項目がタップされたときに呼ばれるコールバックを受け取るコンストラクタ。
   ///
-  /// 必要に応じてkeyを指定できます。
-  const CustomDrawer({super.key});
+  /// [onHistoryTap]は履歴の文字列を引数に取り、タップ時に呼び出されます。
+  const CustomDrawer({required this.onHistoryTap, super.key});
+
+  /// 検索履歴の項目がタップされたときに呼ばれるコールバック。
+  final void Function(String) onHistoryTap;
+
+  /// ドロワーのUIを構築します。
+  ///
+  /// 検索履歴リストやテーマ切り替えボタンなどを表示します。
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      right: false,
+      child: Drawer(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: NumberData.paddingSmall,
+          ),
+          child: Column(
+            children: <Widget>[
+              const _SearchHistoryTitle(),
+              _SearchHistoryListView(
+                onHistoryTap: onHistoryTap,
+              ),
+              const Divider(),
+              const ThemeModeSelectButton(),
+              const ShowOssLicenseButton(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 
   @override
-  /// ドロワーメニューのウィジェットツリーを構築します。
-  ///
-  /// アプリ名のヘッダーやテーマ切り替え、OSSライセンス表示ボタンを含むリストを返します。
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Drawer(
-      child: ListView(
-        physics: const NeverScrollableScrollPhysics(),
-        padding: EdgeInsets.zero,
-        children: <Widget>[
-          DrawerHeader(
-            duration: Duration.zero,
-            child: Text(
-              WordingData.applicationName,
-              style: Theme.of(context).textTheme.headlineSmall,
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        onHistoryTap,
+      ),
+    );
+  }
+}
+
+/// 検索履歴タイトル部分のウィジェット。
+class _SearchHistoryTitle extends StatelessWidget {
+  /// デフォルトコンストラクタ。
+  const _SearchHistoryTitle();
+
+  /// タイトル行のUIを構築します。
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: ListTile(
+            dense: true,
+            leading: const Icon(Icons.history),
+            title: Text(
+              AppLocalizations.of(context)?.searchHistory ??
+                  WordingData.searchHistory,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
-          const ThemeModeSelectButton(),
-          const ShowOssLicenseButton(),
-        ],
+        ),
+        if (kDebugMode) const _ApplyTestDataButton(),
+        IconButton(
+          onPressed: () => Navigator.pop(context),
+          icon: const Icon(Icons.close),
+        ),
+      ],
+    );
+  }
+}
+
+/// 検索履歴リスト部分のウィジェット。
+///
+/// 検索履歴のリストを表示し、履歴項目のタップ時に[onHistoryTap]が呼ばれます。
+class _SearchHistoryListView extends ConsumerStatefulWidget {
+  /// 検索履歴リストのコンストラクタ。
+  ///
+  /// [onHistoryTap]は履歴の文字列を引数に取り、タップ時に呼び出されます。
+  const _SearchHistoryListView({required this.onHistoryTap});
+
+  /// 検索履歴の項目がタップされたときに呼ばれるコールバック。
+  final void Function(String) onHistoryTap;
+
+  /// Stateを生成します。
+  @override
+  ConsumerState<_SearchHistoryListView> createState() =>
+      _SearchHistoryListViewState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        onHistoryTap,
       ),
+    );
+  }
+}
+
+/// 検索履歴リストの状態管理クラス。
+///
+/// スクロールコントローラの管理や、履歴データの監視・表示を行います。
+class _SearchHistoryListViewState
+    extends ConsumerState<_SearchHistoryListView> {
+  /// スクロールコントローラ。
+  final _scrollController = ScrollController();
+
+  /// ウィジェット破棄時にコントローラを破棄します。
+  @override
+  void dispose() {
+    super.dispose();
+    _scrollController.dispose();
+  }
+
+  /// 検索履歴リストのUIを構築します。
+  ///
+  /// 履歴が空の場合はメッセージを表示し、履歴がある場合はリスト表示します。
+  @override
+  Widget build(BuildContext context) {
+    final history = ref.watch(searchHistoryProvider);
+    return Expanded(
+      child: history.when(
+        data: (data) {
+          if (data.isEmpty) {
+            return Center(
+              child: Text(
+                AppLocalizations.of(context)?.noSearchHistory ??
+                    WordingData.noSearchHistory,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            );
+          }
+          return Scrollbar(
+            controller: _scrollController,
+            thumbVisibility: true,
+            child: ListView.builder(
+              controller: _scrollController,
+              itemCount: data.length,
+              itemBuilder: (context, index) {
+                return _SearchHistoryListItem(
+                  index: index,
+                  value: data[index],
+                  onHistoryTap: widget.onHistoryTap,
+                );
+              },
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        widget.onHistoryTap,
+      ),
+    );
+  }
+}
+
+/// 検索履歴リストの各項目ウィジェット。
+///
+/// 履歴の値や削除ボタン、タップ時の挙動を定義します。
+class _SearchHistoryListItem extends ConsumerWidget {
+  /// 検索履歴リスト項目のコンストラクタ。
+  ///
+  /// [index]はリスト内のインデックス、[value]は履歴の値、[onHistoryTap]はタップ時のコールバックです。
+  const _SearchHistoryListItem({
+    required this.index,
+    required this.value,
+    required this.onHistoryTap,
+  });
+
+  /// リスト内のインデックス。
+  final int index;
+
+  /// 履歴の値。
+  final String value;
+
+  /// 履歴項目がタップされたときに呼ばれるコールバック。
+  final void Function(String) onHistoryTap;
+
+  /// 履歴項目のUIを構築します。
+  ///
+  /// タップで履歴を選択、削除ボタンで履歴を削除します。
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      dense: true,
+      visualDensity: const VisualDensity(
+        horizontal: VisualDensity.minimumDensity,
+      ),
+      contentPadding: const EdgeInsets.fromLTRB(
+        NumberData.paddingMedium,
+        0,
+        NumberData.paddingSmall,
+        0,
+      ),
+      horizontalTitleGap: NumberData.paddingSmall,
+      title: Text(
+        value,
+        maxLines: 2,
+        style: Theme.of(context).textTheme.bodySmall,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: IconButton(
+        onPressed: () async {
+          await ref.read(searchHistoryProvider.notifier).removeTo(value);
+        },
+        icon: Icon(
+          Icons.delete,
+          color: Theme.of(context).colorScheme.error,
+        ),
+      ),
+      onTap: () {
+        onHistoryTap(value);
+        Navigator.pop(context);
+      },
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('value', value));
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        onHistoryTap,
+      ),
+    );
+    properties.add(IntProperty('index', index));
+  }
+}
+
+/// テスト用の検索履歴データを適用するボタンウィジェット。
+class _ApplyTestDataButton extends ConsumerWidget {
+  /// デフォルトコンストラクタ。
+  const _ApplyTestDataButton();
+
+  /// テストデータを履歴に追加するボタンのUIを構築します。
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      onPressed: () async {
+        const searchHistories = [
+          'flutter riverpod',
+          'yumemi',
+          'flutter yumemi',
+          'yumemi flutter engineer codecheck repository search',
+          'flutter yumemi',
+          'yumemi engineer',
+          'yumemi engineer codecheck',
+          'jest',
+          'react testing library',
+          'flutter testing',
+          'flutter test',
+          'freezed',
+          'json serialization',
+          'yumemi flutter engineer codecheck',
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+        ];
+        await ref.read(searchHistoryProvider.notifier).clear();
+        for (final s in searchHistories) {
+          await ref.read(searchHistoryProvider.notifier).add(s);
+        }
+      },
+      icon: const Icon(Icons.recycling),
     );
   }
 }

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/domain/entity/repository.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/common/widget/common_repository_card.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/repository_providers.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/search_history_provider.dart';
 import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
@@ -159,7 +160,7 @@ class AdaptiveRepositoryListView extends StatelessWidget {
 /// 検索結果リスト内のリポジトリアイテムを表示するウィジェット
 ///
 /// リポジトリ名やオーナーアイコン、詳細画面への遷移アクションを含みます。
-class _SearchResultListItem extends StatelessWidget {
+class _SearchResultListItem extends ConsumerWidget {
   /// 検索結果リストアイテムのコンストラクタ
   ///
   /// [repository]は表示対象のリポジトリ情報です。
@@ -172,7 +173,7 @@ class _SearchResultListItem extends StatelessWidget {
   /// リポジトリアイテムのウィジェットツリーを構築します。
   ///
   /// ヒーローアニメーションや詳細画面への遷移を含むリストアイテムを返します。
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Hero(
       // ヒーローアニメーションを使用してリポジトリのリストを表示
       // 詳細画面のHeroと同一のタグを使用することでアニメーションを実現している
@@ -185,6 +186,14 @@ class _SearchResultListItem extends StatelessWidget {
         margin: const EdgeInsets.symmetric(vertical: 6),
         showChevron: true,
         onTap: () async {
+          // 検索キーワードを履歴に追加
+          final query = ref.read(gitHubSearchQueryNotifierProvider).q;
+          final a = ref.read(searchHistoryProvider.notifier).add;
+          if (query.isNotEmpty) {
+            Future.delayed(const Duration(milliseconds: 1000), () {
+              a(query);
+            });
+          }
           await GoRouter.of(context).pushNamed('details', extra: repository);
         },
       ),

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
@@ -188,10 +188,9 @@ class _SearchResultListItem extends ConsumerWidget {
         onTap: () async {
           // 検索キーワードを履歴に追加
           final query = ref.read(gitHubSearchQueryNotifierProvider).q;
-          final a = ref.read(searchHistoryProvider.notifier).add;
           if (query.isNotEmpty) {
-            Future.delayed(const Duration(milliseconds: 1000), () {
-              a(query);
+            Future.delayed(const Duration(milliseconds: 1000), () async {
+              await ref.read(searchHistoryProvider.notifier).add(query);
             });
           }
           await GoRouter.of(context).pushNamed('details', extra: repository);

--- a/lib/features/repository_search/presentation/page/repository_search/widget/show_oss_license_button.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/show_oss_license_button.dart
@@ -17,6 +17,11 @@ class ShowOssLicenseButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
+      dense: true,
+      visualDensity: const VisualDensity(
+        vertical: VisualDensity.minimumDensity,
+        horizontal: VisualDensity.minimumDensity,
+      ),
       leading: const Icon(Icons.info),
       title: Text(
         AppLocalizations.of(context)?.ossLicense ?? WordingData.ossLicense,

--- a/lib/features/repository_search/presentation/page/repository_search/widget/theme_mode_select_button.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/theme_mode_select_button.dart
@@ -50,6 +50,11 @@ class ThemeModeSelectButton extends ConsumerWidget {
       },
       initialValue: themeMode.value ?? ThemeMode.system,
       child: ListTile(
+        dense: true,
+        visualDensity: const VisualDensity(
+          vertical: VisualDensity.minimumDensity,
+          horizontal: VisualDensity.minimumDensity,
+        ),
         leading: const Icon(Icons.brightness_6),
         title: Text(
           AppLocalizations.of(context)?.themeModeSelect ??

--- a/lib/features/repository_search/presentation/provider/search_history_provider.dart
+++ b/lib/features/repository_search/presentation/provider/search_history_provider.dart
@@ -1,0 +1,51 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'search_history_provider.g.dart';
+
+/// 検索履歴を管理するRiverpodプロバイダのクラス。
+///
+/// 検索履歴の保存・取得・追加・クリアなどの機能を提供します。
+@riverpod
+class SearchHistory extends _$SearchHistory {
+  /// 検索履歴の最大保存件数。
+  static const _maxHistoryLength = 10;
+
+  /// 検索履歴を保存する際のキー。
+  static const _historyKey = 'search_history';
+
+  /// SharedPreferencesへの非同期アクセス用インスタンス。
+  final _prefs = SharedPreferencesAsync();
+
+  /// 検索履歴を非同期で取得します。
+  ///
+  /// SharedPreferencesから履歴を取得し、存在しない場合は空リストを返します。
+  @override
+  Future<List<String>> build() async {
+    final searchHistory = await _prefs.getStringList(_historyKey);
+    return searchHistory ?? [];
+  }
+
+  /// 検索キーワードを履歴に追加します。
+  ///
+  /// 既存の履歴から重複を除外し、最大件数を超えないように保存します。
+  /// 空文字列は追加されません。
+  Future<void> add(String keyword) async {
+    if (keyword.isEmpty) {
+      return;
+    }
+    final current = state.value ?? [];
+    final newHistory = [keyword, ...current.where((e) => e != keyword)];
+    final limitedHistory = newHistory.take(_maxHistoryLength).toList();
+    await _prefs.setStringList(_historyKey, limitedHistory);
+    state = AsyncData(limitedHistory);
+  }
+
+  /// 検索履歴をすべて削除します。
+  ///
+  /// SharedPreferences上の履歴も空リストとして保存されます。
+  Future<void> clear() async {
+    await _prefs.setStringList(_historyKey, []);
+    state = const AsyncData([]);
+  }
+}

--- a/lib/features/repository_search/presentation/provider/search_history_provider.dart
+++ b/lib/features/repository_search/presentation/provider/search_history_provider.dart
@@ -48,4 +48,11 @@ class SearchHistory extends _$SearchHistory {
     await _prefs.setStringList(_historyKey, []);
     state = const AsyncData([]);
   }
+
+  Future<void> removeTo(String data) async {
+    final current = state.value ?? [];
+    final newHistory = current.where((e) => e != data).toList();
+    await _prefs.setStringList(_historyKey, newHistory);
+    state = AsyncData(newHistory);
+  }
 }

--- a/lib/features/repository_search/presentation/provider/search_history_provider.g.dart
+++ b/lib/features/repository_search/presentation/provider/search_history_provider.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_history_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$searchHistoryHash() => r'641b591ed75d6eb22798352de7f8cd65f250d7f9';
+
+/// 検索履歴を管理するRiverpodプロバイダのクラス。
+///
+/// 検索履歴の保存・取得・追加・クリアなどの機能を提供します。
+///
+/// Copied from [SearchHistory].
+@ProviderFor(SearchHistory)
+final searchHistoryProvider =
+    AutoDisposeAsyncNotifierProvider<SearchHistory, List<String>>.internal(
+      SearchHistory.new,
+      name: r'searchHistoryProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$searchHistoryHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SearchHistory = AutoDisposeAsyncNotifier<List<String>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/repository_search/presentation/provider/search_history_provider.g.dart
+++ b/lib/features/repository_search/presentation/provider/search_history_provider.g.dart
@@ -6,7 +6,7 @@ part of 'search_history_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$searchHistoryHash() => r'641b591ed75d6eb22798352de7f8cd65f250d7f9';
+String _$searchHistoryHash() => r'2fc37c170660987940da30dfa1a7a256a4029b7e';
 
 /// 検索履歴を管理するRiverpodプロバイダのクラス。
 ///

--- a/lib/features/repository_search/presentation/provider/search_history_provider.g.dart
+++ b/lib/features/repository_search/presentation/provider/search_history_provider.g.dart
@@ -6,7 +6,7 @@ part of 'search_history_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$searchHistoryHash() => r'2fc37c170660987940da30dfa1a7a256a4029b7e';
+String _$searchHistoryHash() => r'875616db5678f11ed1c1494e7f227a9a7ad91be9';
 
 /// 検索履歴を管理するRiverpodプロバイダのクラス。
 ///

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -58,5 +58,13 @@
   "inputKeyword": "Input search keyword",
   "@inputKeyword": {
     "description": "Label for prompting user to input search keyword."
+  },
+  "clearHistory": "Clear search history",
+  "@clearHistory": {
+    "description": "Tooltip for clearing search history."
+  },
+  "searchHistory": "Search History",
+  "@searchHistory": {
+    "description": "The title for the search history section."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -66,5 +66,9 @@
   "searchHistory": "Search History",
   "@searchHistory": {
     "description": "The title for the search history section."
+  },
+  "noSearchHistory": "No search history.",
+  "@noSearchHistory": {
+    "description": "Message shown when there is no search history."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -15,5 +15,6 @@
   "repoDetailsInfo": "リポジトリ詳細",
   "inputKeyword": "検索キーワードを入力してください",
   "clearHistory": "検索履歴をクリアします",
-  "searchHistory": "検索履歴"
+  "searchHistory": "検索履歴",
+  "noSearchHistory": "検索履歴はありません。"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -13,5 +13,7 @@
   "repoForks": "フォーク",
   "repoIssues": "イシュー",
   "repoDetailsInfo": "リポジトリ詳細",
-  "inputKeyword": "検索キーワードを入力してください"
+  "inputKeyword": "検索キーワードを入力してください",
+  "clearHistory": "検索履歴をクリアします",
+  "searchHistory": "検索履歴"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -187,6 +187,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Input search keyword'**
   String get inputKeyword;
+
+  /// Tooltip for clearing search history.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear search history'**
+  String get clearHistory;
+
+  /// The title for the search history section.
+  ///
+  /// In en, this message translates to:
+  /// **'Search History'**
+  String get searchHistory;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -199,6 +199,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Search History'**
   String get searchHistory;
+
+  /// Message shown when there is no search history.
+  ///
+  /// In en, this message translates to:
+  /// **'No search history.'**
+  String get noSearchHistory;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -52,4 +52,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get inputKeyword => 'Input search keyword';
+
+  @override
+  String get clearHistory => 'Clear search history';
+
+  @override
+  String get searchHistory => 'Search History';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -58,4 +58,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchHistory => 'Search History';
+
+  @override
+  String get noSearchHistory => 'No search history.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -58,4 +58,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get searchHistory => '検索履歴';
+
+  @override
+  String get noSearchHistory => '検索履歴はありません。';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -52,4 +52,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get inputKeyword => '検索キーワードを入力してください';
+
+  @override
+  String get clearHistory => '検索履歴をクリアします';
+
+  @override
+  String get searchHistory => '検索履歴';
 }

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -16,3 +16,4 @@ repoDetailsInfo,The title for the repository details page.,Repository Details In
 inputKeyword,Label for prompting user to input search keyword.,Input search keyword,検索キーワードを入力してください
 clearHistory,Tooltip for clearing search history.,Clear search history,検索履歴をクリアします
 searchHistory,The title for the search history section.,Search History,検索履歴
+noSearchHistory,Message shown when there is no search history.,No search history.,検索履歴はありません。

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -14,3 +14,5 @@ repoForks,The number of forks of the repository.,Forks,フォーク
 repoIssues,The number of open issues of the repository.,Issues,イシュー
 repoDetailsInfo,The title for the repository details page.,Repository Details Info,リポジトリ詳細
 inputKeyword,Label for prompting user to input search keyword.,Input search keyword,検索キーワードを入力してください
+clearHistory,Tooltip for clearing search history.,Clear search history,検索履歴をクリアします
+searchHistory,The title for the search history section.,Search History,検索履歴

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -58,4 +58,7 @@ class WordingData {
 
   /// 検索履歴セクションのタイトル。ドロワーや履歴表示で利用されます。
   static const searchHistory = 'Search History';
+
+  /// 検索履歴が空の場合の表示文言。検索履歴が存在しない場合に利用されます。
+  static const noSearchHistory = 'No search history.';
 }

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -52,4 +52,10 @@ class WordingData {
 
   /// 未検索状態の表示用ラベル。リポジトリがまだ検索されていない場合に利用されます。
   static const inputKeyword = 'Input search keyword';
+
+  /// 検索履歴クリアボタンのツールチップ。検索履歴を削除する際に利用されます。
+  static const clearHistory = 'Clear search history';
+
+  /// 検索履歴セクションのタイトル。ドロワーや履歴表示で利用されます。
+  static const searchHistory = 'Search History';
 }

--- a/test/features/repository_search/presentation/page/repository_search/repository_search_page_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/repository_search_page_test.dart
@@ -380,7 +380,9 @@ class TestSearchHistory extends SearchHistory {
 
   @override
   Future<void> add(String keyword) async {
-    if (keyword.isEmpty) return;
+    if (keyword.isEmpty) {
+      return;
+    }
     _history = [keyword, ..._history.where((e) => e != keyword)];
     _history = _history.take(10).toList();
     state = AsyncData(_history);

--- a/test/features/repository_search/presentation/page/repository_search/widget/custom_drawer_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/custom_drawer_test.dart
@@ -213,7 +213,9 @@ class TestSearchHistory extends SearchHistory {
 
   @override
   Future<void> add(String keyword) async {
-    if (keyword.isEmpty) return;
+    if (keyword.isEmpty) {
+      return;
+    }
     _history = [keyword, ..._history.where((e) => e != keyword)];
     _history = _history.take(10).toList();
     state = AsyncData(_history);

--- a/test/features/repository_search/presentation/page/repository_search/widget/custom_drawer_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/custom_drawer_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/repository_search_page.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/search_history_provider.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 
 import '../../../../../../mock/mock_shared_preferences_async_platform.dart';
@@ -78,7 +79,9 @@ void main() {
           child: MaterialApp(
             home: Scaffold(
               key: scaffoldKey,
-              drawer: const CustomDrawer(),
+              drawer: CustomDrawer(
+                onHistoryTap: (_) {},
+              ),
             ),
           ),
         ),
@@ -88,7 +91,7 @@ void main() {
       scaffoldKey.currentState!.openDrawer();
       await tester.pumpAndSettle();
 
-      expect(find.text(WordingData.applicationName), findsOneWidget);
+      expect(find.text(WordingData.searchHistory), findsOneWidget);
       expect(find.byIcon(Icons.brightness_6), findsOneWidget);
 
       expect(find.text(WordingData.ossLicense), findsOneWidget);
@@ -101,4 +104,130 @@ void main() {
       expect(find.text(WordingData.themeModeDark), findsOneWidget);
     });
   });
+
+  group('CustomDrawerの追加テスト', () {
+    testWidgets('検索履歴が空の場合、履歴なしメッセージが表示される', (tester) async {
+      final scaffoldKey = GlobalKey<ScaffoldState>();
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              key: scaffoldKey,
+              drawer: CustomDrawer(onHistoryTap: (_) {}),
+            ),
+          ),
+        ),
+      );
+      scaffoldKey.currentState!.openDrawer();
+      await tester.pumpAndSettle();
+      expect(find.text(WordingData.noSearchHistory), findsOneWidget);
+    });
+
+    testWidgets('検索履歴が表示され、タップでonHistoryTapが呼ばれる', (tester) async {
+      final scaffoldKey = GlobalKey<ScaffoldState>();
+      String? tappedValue;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchHistoryProvider.overrideWith(
+              () => TestSearchHistory(['test1', 'test2']),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              key: scaffoldKey,
+              drawer: CustomDrawer(onHistoryTap: (v) => tappedValue = v),
+            ),
+          ),
+        ),
+      );
+      scaffoldKey.currentState!.openDrawer();
+      await tester.pumpAndSettle();
+      expect(find.text('test1'), findsOneWidget);
+      expect(find.text('test2'), findsOneWidget);
+      await tester.tap(find.text('test1'));
+      await tester.pumpAndSettle();
+      expect(tappedValue, 'test1');
+    });
+
+    testWidgets('履歴削除ボタンで履歴が削除される', (tester) async {
+      final scaffoldKey = GlobalKey<ScaffoldState>();
+      final testHistory = TestSearchHistory(['test1', 'test2']);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchHistoryProvider.overrideWith(() => testHistory),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              key: scaffoldKey,
+              drawer: CustomDrawer(onHistoryTap: (_) {}),
+            ),
+          ),
+        ),
+      );
+      scaffoldKey.currentState!.openDrawer();
+      await tester.pumpAndSettle();
+      expect(find.text('test1'), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.delete).first);
+      await tester.pumpAndSettle();
+      expect(testHistory.state.value!.contains('test1'), isFalse);
+    });
+
+    testWidgets('テストデータ適用ボタンで履歴が追加される', (tester) async {
+      final scaffoldKey = GlobalKey<ScaffoldState>();
+      final testHistory = TestSearchHistory();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchHistoryProvider.overrideWith(() => testHistory),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              key: scaffoldKey,
+              drawer: CustomDrawer(onHistoryTap: (_) {}),
+            ),
+          ),
+        ),
+      );
+      scaffoldKey.currentState!.openDrawer();
+      await tester.pumpAndSettle();
+      if (find.byIcon(Icons.recycling).evaluate().isNotEmpty) {
+        await tester.tap(find.byIcon(Icons.recycling));
+        await tester.pumpAndSettle();
+        expect(testHistory.state.value!.isNotEmpty, isTrue);
+      }
+    });
+  });
+}
+
+// テスト用の検索履歴管理クラス
+class TestSearchHistory extends SearchHistory {
+  TestSearchHistory([List<String>? initial]) : _history = initial ?? [];
+  List<String> _history;
+
+  @override
+  Future<List<String>> build() async {
+    return _history;
+  }
+
+  @override
+  Future<void> add(String keyword) async {
+    if (keyword.isEmpty) return;
+    _history = [keyword, ..._history.where((e) => e != keyword)];
+    _history = _history.take(10).toList();
+    state = AsyncData(_history);
+  }
+
+  @override
+  Future<void> clear() async {
+    _history = [];
+    state = const AsyncData([]);
+  }
+
+  @override
+  Future<void> removeTo(String data) async {
+    _history = _history.where((e) => e != data).toList();
+    state = AsyncData(_history);
+  }
 }


### PR DESCRIPTION
## 概要

検索履歴機能を追加し、検索履歴の表示・選択・削除・テストデータ適用ができるようになりました。UIの一部調整や国際化対応も含まれます。

## 関連Issue

#88 

## 変更内容

### 主な内容

- 検索履歴機能の新規追加（追加削除程度の機能かつアプリ内機能のため domain 層は扱わない）
  - `lib/features/repository_search/presentation/provider/search_history_provider.dart`
  - `lib/features/repository_search/presentation/provider/search_history_provider.g.dart`
- 検索ページ・ドロワーのUI/ロジック拡張
  - 検索履歴リストの表示・選択・削除・テストデータ適用
    - `lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart`
    - `lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart`
    - `lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart`
    - `lib/features/repository_search/presentation/page/repository_search/widget/show_oss_license_button.dart`
    - `lib/features/repository_search/presentation/page/repository_search/widget/theme_mode_select_button.dart`
- 文言対応
  - `lib/l10n/app_en.arb`
  - `lib/l10n/app_ja.arb`
  - `lib/l10n/app_localizations.dart`
  - `lib/l10n/app_localizations_en.dart`
  - `lib/l10n/app_localizations_ja.dart`
  - `lib/l10n/strings.csv`
  - `lib/static/wording_data.dart`
- テストコードの追加・拡充
  - `test/features/repository_search/presentation/page/repository_search/repository_search_page_test.dart`
  - `test/features/repository_search/presentation/page/repository_search/widget/custom_drawer_test.dart`
- プロンプトファイルの微修正
  - `.github/prompts/add_wording.prompt.md`

## 動作確認内容

- 検索画面からリポジトリ選択して詳細画面に行ったあと戻ってきてドロワーを開いたら検索履歴が追加されていること
- 検索履歴をタップしたあとドロワーが閉じ、検索が行われていること
- 検索履歴を削除できること

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください --