### PR TITLE
デプロイワークフローでのGitコミッター設定を分離し、リリースブランチへのマージ前に設定するように変更

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,11 @@ jobs:
           git fetch origin release:release || git checkout --orphan release
           git checkout release
 
+      - name: Set git committer
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
       - name: Merge main into release
         run: git merge --no-ff origin/main
 
@@ -44,8 +49,6 @@ jobs:
 
       - name: Commit and push to release
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
           git add docs
           git commit -m "chore: update docs with latest web build [skip ci]" || echo "No changes to commit"
           git push origin release


### PR DESCRIPTION
## 概要

GitHub Actionsのデプロイワークフロー（deploy.yaml）において、コミッター情報の設定ステップを追加し、重複していた設定を整理しました。

## 関連Issue

#65

## 変更内容

### 主な内容

- コミッター情報（user.email, user.name）の設定ステップを `Merge main into release` の前に新規追加
  - `.github/workflows/deploy.yaml`
- これまで `Commit and push to release` ステップ内にあったコミッター情報の設定を削除し、重複を解消
  - `.github/workflows/deploy.yaml`

## 動作確認内容

<!-- このまま記して下さい -->

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください --