### PR TITLE
デプロイジョブにGitのコンテンツ書き込み権限を追加

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 概要

GitHub Actions のデプロイワークフローに `permissions` 設定を追加し、GITHUB_TOKEN で release ブランチへの push 権限を明示的に付与しました。

## 関連Issue

#65

## 変更内容

### 主な内容

- GITHUB Actions ワークフローの権限設定を追加
  - `.github/workflows/deploy.yaml`
    - `jobs.build-and-deploy` の直下に `permissions: contents: write` を追加

## 動作確認内容

<!-- このまま記して下さい -->

## 補足

- これにより、release ブランチへの push 時の 403 エラーが解消される見込みです。
- ブランチ保護ルールが厳しい場合は、リポジトリ設定を確認する