### PR TITLE
Controller類の dispose し忘れを防ぐ修正を行なった

### DIFF
--- a/lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
@@ -26,6 +26,12 @@ class _SearchPageState extends ConsumerState<RepositorySearchPage> {
   /// 検索テキストフィールドの入力内容を管理するコントローラーです。
   final controller = TextEditingController();
 
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
   /// リポジトリ検索ページのUIを構築します。
   ///
   /// 検索テキストフィールドや検索結果リストなど、ページ全体のレイアウトを定義します。

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_text_field.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_text_field.dart
@@ -11,8 +11,8 @@ class SearchTextField extends StatelessWidget {
   /// [onCancelButtonPressed]でキャンセルボタン押下時の処理、[labelText]でラベル表示、
   /// [onSubmitted]でエンター押下時の処理を指定できます。
   const SearchTextField({
+    required this.controller,
     super.key,
-    this.controller,
     this.onChanged,
     this.onCancelButtonPressed,
     this.labelText,
@@ -22,7 +22,7 @@ class SearchTextField extends StatelessWidget {
   /// テキストフィールドのコントローラー
   ///
   /// 入力値の取得や制御に利用します。
-  final TextEditingController? controller;
+  final TextEditingController controller;
 
   /// 入力値が変更されたときに呼ばれるコールバック
   final void Function(String)? onChanged;
@@ -44,7 +44,7 @@ class SearchTextField extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
       child: TextField(
-        controller: controller ?? TextEditingController(),
+        controller: controller,
         decoration: InputDecoration(
           prefixIcon: const Icon(Icons.search),
           suffixIcon: IconButton(

--- a/test/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_test.dart
+++ b/test/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_test.dart
@@ -9,6 +9,13 @@ import '../../../../../../test_util/test_util.dart';
 
 void main() {
   group('HeroアニメーションのUXテスト', () {
+    late ScrollController controller;
+    setUp(() {
+      controller = ScrollController();
+    });
+    tearDown(() {
+      controller.dispose();
+    });
     testWidgets(
       'ユーザーがリポジトリリストから詳細画面に遷移する時、自然なアニメーションが実行される',
       (tester) async {
@@ -29,7 +36,7 @@ void main() {
           appBar: AppBar(title: const Text('検索結果')),
           body: AdaptiveRepositoryListView(
             value: const [testRepository],
-            scrollController: ScrollController(),
+            scrollController: controller,
           ),
         );
 
@@ -110,7 +117,7 @@ void main() {
           home: Scaffold(
             body: AdaptiveRepositoryListView(
               value: const [testRepository],
-              scrollController: ScrollController(),
+              scrollController: controller,
             ),
           ),
         );
@@ -157,7 +164,7 @@ void main() {
           home: Scaffold(
             body: AdaptiveRepositoryListView(
               value: const [testRepository],
-              scrollController: ScrollController(),
+              scrollController: controller,
             ),
           ),
         );

--- a/test/features/repository_search/presentation/page/repository_search/widget/search_text_field_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/search_text_field_test.dart
@@ -4,11 +4,21 @@ import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/pre
 
 void main() {
   group('SearchTextField', () {
+    late TextEditingController controller;
+    setUp(() {
+      controller = TextEditingController();
+    });
+    tearDown(() {
+      controller.dispose();
+    });
     testWidgets('labelTextが表示される', (tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Scaffold(
-            body: SearchTextField(labelText: '検索'),
+            body: SearchTextField(
+              controller: controller,
+              labelText: '検索',
+            ),
           ),
         ),
       );
@@ -21,6 +31,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: SearchTextField(
+              controller: controller,
               onChanged: (v) => value = v,
             ),
           ),
@@ -36,6 +47,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: SearchTextField(
+              controller: controller,
               onCancelButtonPressed: () => pressed = true,
             ),
           ),
@@ -46,7 +58,6 @@ void main() {
     });
 
     testWidgets('テキスト入力時にTextFieldに表示される', (tester) async {
-      final controller = TextEditingController();
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -69,6 +80,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: SearchTextField(
+              controller: controller,
               onSubmitted: (v) => submittedValue = v,
             ),
           ),


### PR DESCRIPTION
## 概要

TextEditingControllerやScrollControllerのライフサイクル管理を強化し、リソースリークを防止するための修正を行いました。また、関連するテストコードも修正し、コントローラの管理方法を統一しました。

## 関連Issue

#107 

## 変更内容

### 主な内容

- TextEditingControllerのdispose追加
  - lib/features/repository_search/presentation/page/repository_search/repository_search_page.dart
    - Stateクラスでcontrollerのdisposeを明示的に実装

- SearchTextFieldのAPI変更
  - lib/features/repository_search/presentation/page/repository_search/widget/search_text_field.dart
    - controllerを必須(required)パラメータに変更し、null許容を廃止

- テストコードのコントローラ管理統一
  - test/features/repository_search/presentation/page/repository_search/widget/search_text_field_test.dart
    - setUp/tearDownでcontrollerを生成・破棄するよう修正
    - SearchTextFieldのテストでcontrollerを必ず渡すよう修正

- ScrollControllerのライフサイクル管理強化
  - test/features/repository_search/presentation/page/repository_details/widget/repository_hero_animation_test.dart
    - setUp/tearDownでcontrollerを生成・破棄するよう修正
    - AdaptiveRepositoryListViewに同一controllerを渡すよう修正

## 動作確認内容

対象箇所を動作確認した。
テストコードが全て通ることを確認した。

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください --