### PR TITLE
非同期のコールバック内でマウントされているか確認する条件を追加した

### DIFF
--- a/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
@@ -236,6 +236,9 @@ class _SearchHistoryListItem extends ConsumerWidget {
       ),
       trailing: IconButton(
         onPressed: () async {
+          if (!context.mounted || !ref.context.mounted) {
+            return;
+          }
           await ref.read(searchHistoryProvider.notifier).removeTo(value);
         },
         icon: Icon(
@@ -274,6 +277,9 @@ class _ApplyTestDataButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return IconButton(
       onPressed: () async {
+        if (!context.mounted || !ref.context.mounted) {
+          return;
+        }
         const searchHistories = [
           'flutter riverpod',
           'yumemi',

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
@@ -186,6 +186,9 @@ class _SearchResultListItem extends ConsumerWidget {
         margin: const EdgeInsets.symmetric(vertical: 6),
         showChevron: true,
         onTap: () async {
+          if (!context.mounted || !ref.context.mounted) {
+            return;
+          }
           // 検索キーワードを履歴に追加
           final query = ref.read(gitHubSearchQueryNotifierProvider).q;
           if (query.isNotEmpty) {


### PR DESCRIPTION
## 概要

`context.mounted`と`ref.context.mounted`のチェックを追加し、非同期コールバック内でウィジェットが破棄されている場合の安全性を向上させました。

## 関連Issue

#106 

## 変更内容

### 主な内容

- 非同期コールバック内で`context.mounted`と`ref.context.mounted`のチェックを追加
  - lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
    - 検索履歴削除ボタン、テストデータ適用ボタンのonPressed内
  - lib/features/repository_search/presentation/page/repository_search/widget/search_result_list_view.dart
    - 検索結果リストアイテムのonTap内

## 動作確認内容

修正箇所で動作に問題がないことを確認した。
テストが通ることを確認した。

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->