### PR TITLE
Feature/apply animation to search history listview

### DIFF
--- a/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/show_oss_license_button.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/theme_mode_select_button.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/search_history_provider.dart';
@@ -35,7 +36,7 @@ class CustomDrawer extends ConsumerWidget {
           child: Column(
             children: <Widget>[
               const _SearchHistoryTitle(),
-              _SearchHistoryListView(
+              SearchHistoryListView(
                 onHistoryTap: onHistoryTap,
               ),
               const Divider(),
@@ -93,179 +94,6 @@ class _SearchHistoryTitle extends StatelessWidget {
   }
 }
 
-/// 検索履歴リスト部分のウィジェット。
-///
-/// 検索履歴のリストを表示し、履歴項目のタップ時に[onHistoryTap]が呼ばれます。
-class _SearchHistoryListView extends ConsumerStatefulWidget {
-  /// 検索履歴リストのコンストラクタ。
-  ///
-  /// [onHistoryTap]は履歴の文字列を引数に取り、タップ時に呼び出されます。
-  const _SearchHistoryListView({required this.onHistoryTap});
-
-  /// 検索履歴の項目がタップされたときに呼ばれるコールバック。
-  final void Function(String) onHistoryTap;
-
-  /// Stateを生成します。
-  @override
-  ConsumerState<_SearchHistoryListView> createState() =>
-      _SearchHistoryListViewState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(
-      ObjectFlagProperty<void Function(String)>.has(
-        'onHistoryTap',
-        onHistoryTap,
-      ),
-    );
-  }
-}
-
-/// 検索履歴リストの状態管理クラス。
-///
-/// スクロールコントローラの管理や、履歴データの監視・表示を行います。
-class _SearchHistoryListViewState
-    extends ConsumerState<_SearchHistoryListView> {
-  /// スクロールコントローラ。
-  final _scrollController = ScrollController();
-
-  /// ウィジェット破棄時にコントローラを破棄します。
-  @override
-  void dispose() {
-    super.dispose();
-    _scrollController.dispose();
-  }
-
-  /// 検索履歴リストのUIを構築します。
-  ///
-  /// 履歴が空の場合はメッセージを表示し、履歴がある場合はリスト表示します。
-  @override
-  Widget build(BuildContext context) {
-    final history = ref.watch(searchHistoryProvider);
-    return Expanded(
-      child: history.when(
-        data: (data) {
-          if (data.isEmpty) {
-            return Center(
-              child: Text(
-                AppLocalizations.of(context)?.noSearchHistory ??
-                    WordingData.noSearchHistory,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            );
-          }
-          return Scrollbar(
-            controller: _scrollController,
-            thumbVisibility: true,
-            child: ListView.builder(
-              controller: _scrollController,
-              itemCount: data.length,
-              itemBuilder: (context, index) {
-                return _SearchHistoryListItem(
-                  index: index,
-                  value: data[index],
-                  onHistoryTap: widget.onHistoryTap,
-                );
-              },
-            ),
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, _) => const SizedBox.shrink(),
-      ),
-    );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(
-      ObjectFlagProperty<void Function(String)>.has(
-        'onHistoryTap',
-        widget.onHistoryTap,
-      ),
-    );
-  }
-}
-
-/// 検索履歴リストの各項目ウィジェット。
-///
-/// 履歴の値や削除ボタン、タップ時の挙動を定義します。
-class _SearchHistoryListItem extends ConsumerWidget {
-  /// 検索履歴リスト項目のコンストラクタ。
-  ///
-  /// [index]はリスト内のインデックス、[value]は履歴の値、[onHistoryTap]はタップ時のコールバックです。
-  const _SearchHistoryListItem({
-    required this.index,
-    required this.value,
-    required this.onHistoryTap,
-  });
-
-  /// リスト内のインデックス。
-  final int index;
-
-  /// 履歴の値。
-  final String value;
-
-  /// 履歴項目がタップされたときに呼ばれるコールバック。
-  final void Function(String) onHistoryTap;
-
-  /// 履歴項目のUIを構築します。
-  ///
-  /// タップで履歴を選択、削除ボタンで履歴を削除します。
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return ListTile(
-      dense: true,
-      visualDensity: const VisualDensity(
-        horizontal: VisualDensity.minimumDensity,
-      ),
-      contentPadding: const EdgeInsets.fromLTRB(
-        NumberData.paddingMedium,
-        0,
-        NumberData.paddingSmall,
-        0,
-      ),
-      horizontalTitleGap: NumberData.paddingSmall,
-      title: Text(
-        value,
-        maxLines: 2,
-        style: Theme.of(context).textTheme.bodySmall,
-        overflow: TextOverflow.ellipsis,
-      ),
-      trailing: IconButton(
-        onPressed: () async {
-          if (!context.mounted || !ref.context.mounted) {
-            return;
-          }
-          await ref.read(searchHistoryProvider.notifier).removeTo(value);
-        },
-        icon: Icon(
-          Icons.delete,
-          color: Theme.of(context).colorScheme.error,
-        ),
-      ),
-      onTap: () {
-        onHistoryTap(value);
-        Navigator.pop(context);
-      },
-    );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(StringProperty('value', value));
-    properties.add(
-      ObjectFlagProperty<void Function(String)>.has(
-        'onHistoryTap',
-        onHistoryTap,
-      ),
-    );
-    properties.add(IntProperty('index', index));
-  }
-}
 
 /// テスト用の検索履歴データを適用するボタンウィジェット。
 class _ApplyTestDataButton extends ConsumerWidget {

--- a/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart
@@ -94,7 +94,6 @@ class _SearchHistoryTitle extends StatelessWidget {
   }
 }
 
-
 /// テスト用の検索履歴データを適用するボタンウィジェット。
 class _ApplyTestDataButton extends ConsumerWidget {
   /// デフォルトコンストラクタ。

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/search_history_provider.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+
+/// 検索履歴リスト部分のウィジェット。
+///
+/// 検索履歴のリストを表示し、履歴項目のタップ時に[onHistoryTap]が呼ばれます。
+class SearchHistoryListView extends ConsumerStatefulWidget {
+  /// 検索履歴リストのコンストラクタ。
+  ///
+  /// [onHistoryTap]は履歴の文字列を引数に取り、タップ時に呼び出されます。
+  const SearchHistoryListView({required this.onHistoryTap, super.key});
+
+  /// 検索履歴の項目がタップされたときに呼ばれるコールバック。
+  final void Function(String) onHistoryTap;
+
+  /// Stateを生成します。
+  @override
+  ConsumerState<SearchHistoryListView> createState() =>
+      _SearchHistoryListViewState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        onHistoryTap,
+      ),
+    );
+  }
+}
+
+/// 検索履歴リストの状態管理クラス。
+///
+/// スクロールコントローラの管理や、履歴データの監視・表示を行います。
+class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
+  final _scrollController = ScrollController();
+  final _listKey = GlobalKey<AnimatedListState>();
+  List<String> _oldHistory = [];
+
+  static const _animationDuration = Duration(milliseconds: 150);
+
+  @override
+  void dispose() {
+    super.dispose();
+    _scrollController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final historyAsync = ref.watch(searchHistoryProvider);
+    return Expanded(
+      child: historyAsync.when(
+        data: (history) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _updateAnimatedList(history);
+          });
+          // AnimatedListStateがまだ取得できていない場合は、_oldHistoryをhistoryで初期化
+          if (_listKey.currentState == null &&
+              _oldHistory.length != history.length) {
+            _oldHistory = List.from(history);
+          }
+          if (_oldHistory.isEmpty) {
+            return Center(
+              child: Text(
+                AppLocalizations.of(context)?.noSearchHistory ??
+                    WordingData.noSearchHistory,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            );
+          }
+          return Scrollbar(
+            controller: _scrollController,
+            thumbVisibility: true,
+            child: AnimatedList(
+              key: _listKey,
+              controller: _scrollController,
+              initialItemCount: _oldHistory.length,
+              itemBuilder: (context, index, animation) {
+                return SizeTransition(
+                  sizeFactor: CurvedAnimation(
+                    parent: animation,
+                    curve: Curves.easeInOut,
+                  ),
+                  child: _SearchHistoryListItem(
+                    index: index,
+                    value: _oldHistory[index],
+                    onHistoryTap: widget.onHistoryTap,
+                  ),
+                );
+              },
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  void _updateAnimatedList(List<String> newHistory) {
+    final listState = _listKey.currentState;
+    if (listState == null) {
+      _oldHistory = List.from(newHistory);
+      return;
+    }
+    // 差分検出
+    final old = List<String>.from(_oldHistory);
+    final newList = List<String>.from(newHistory);
+    // 削除
+    for (var i = old.length - 1; i >= 0; i--) {
+      if (!newList.contains(old[i])) {
+        listState.removeItem(
+          i,
+          (context, animation) => SizeTransition(
+            sizeFactor: CurvedAnimation(
+              parent: animation,
+              curve: Curves.easeInOut,
+            ),
+            child: _SearchHistoryListItem(
+              index: i,
+              value: old[i],
+              onHistoryTap: widget.onHistoryTap,
+            ),
+          ),
+          duration: _animationDuration,
+        );
+        _oldHistory.removeAt(i);
+      }
+    }
+    // 追加
+    for (var i = 0; i < newList.length; i++) {
+      if (i >= _oldHistory.length || _oldHistory[i] != newList[i]) {
+        _oldHistory.insert(i, newList[i]);
+        listState.insertItem(i, duration: _animationDuration);
+      }
+    }
+    // 長さ調整
+    if (_oldHistory.length > newList.length) {
+      _oldHistory = List.from(newList);
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        widget.onHistoryTap,
+      ),
+    );
+  }
+}
+
+/// 検索履歴リストの各項目ウィジェット。
+///
+/// 履歴の値や削除ボタン、タップ時の挙動を定義します。
+class _SearchHistoryListItem extends ConsumerWidget {
+  /// 検索履歴リスト項目のコンストラクタ。
+  ///
+  /// [index]はリスト内のインデックス、[value]は履歴の値、[onHistoryTap]はタップ時のコールバックです。
+  const _SearchHistoryListItem({
+    required this.index,
+    required this.value,
+    required this.onHistoryTap,
+  });
+
+  /// リスト内のインデックス。
+  final int index;
+
+  /// 履歴の値。
+  final String value;
+
+  /// 履歴項目がタップされたときに呼ばれるコールバック。
+  final void Function(String) onHistoryTap;
+
+  /// 履歴項目のUIを構築します。
+  ///
+  /// タップで履歴を選択、削除ボタンで履歴を削除します。
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      dense: true,
+      visualDensity: const VisualDensity(
+        horizontal: VisualDensity.minimumDensity,
+      ),
+      contentPadding: const EdgeInsets.fromLTRB(
+        NumberData.paddingMedium,
+        0,
+        NumberData.paddingSmall,
+        0,
+      ),
+      horizontalTitleGap: NumberData.paddingSmall,
+      title: Text(
+        value,
+        maxLines: 2,
+        style: Theme.of(context).textTheme.bodySmall,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: IconButton(
+        onPressed: () async {
+          if (!context.mounted || !ref.context.mounted) {
+            return;
+          }
+          await ref.read(searchHistoryProvider.notifier).removeTo(value);
+        },
+        icon: Icon(
+          Icons.delete,
+          color: Theme.of(context).colorScheme.error,
+        ),
+      ),
+      onTap: () {
+        onHistoryTap(value);
+        Navigator.pop(context);
+      },
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('value', value));
+    properties.add(
+      ObjectFlagProperty<void Function(String)>.has(
+        'onHistoryTap',
+        onHistoryTap,
+      ),
+    );
+    properties.add(IntProperty('index', index));
+  }
+}

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
@@ -136,7 +136,7 @@ class _ConfirmedSearchHistoryListView extends StatelessWidget {
               parent: animation,
               curve: Curves.easeInOut,
             ),
-            child: _SearchHistoryListItem(
+            child: SearchHistoryListItem(
               index: index,
               value: viewModel.internalList[index],
               onHistoryTap: widget.onHistoryTap,
@@ -159,14 +159,15 @@ class _ConfirmedSearchHistoryListView extends StatelessWidget {
 /// 検索履歴リストの各項目ウィジェット。
 ///
 /// 履歴の値や削除ボタン、タップ時の挙動を定義します。
-class _SearchHistoryListItem extends ConsumerWidget {
+class SearchHistoryListItem extends ConsumerWidget {
   /// 検索履歴リスト項目のコンストラクタ。
   ///
   /// [index]はリスト内のインデックス、[value]は履歴の値、[onHistoryTap]はタップ時のコールバックです。
-  const _SearchHistoryListItem({
+  const SearchHistoryListItem({
     required this.index,
     required this.value,
     required this.onHistoryTap,
+    super.key,
   });
 
   /// リスト内のインデックス。

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
@@ -100,15 +100,27 @@ class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
   }
 }
 
+/// 検索履歴リストの内容が確定した状態で表示するウィジェット。
+///
+/// AnimatedListを用いて、確定した検索履歴リストを表示します。
 class _ConfirmedSearchHistoryListView extends StatelessWidget {
+  /// [viewModel]と[widget]を受け取るコンストラクタ。
+  ///
+  /// [viewModel]はリストの状態管理、[widget]は親ウィジェットを参照します。
   const _ConfirmedSearchHistoryListView({
     required this.viewModel,
     required this.widget,
   });
 
+  /// 検索履歴リストの状態管理を行うViewModel。
   final SearchHistoryListViewModel viewModel;
+
+  /// 親のSearchHistoryListViewウィジェット。
   final SearchHistoryListView widget;
 
+  /// AnimatedListを用いて検索履歴リストのUIを構築します。
+  ///
+  /// スクロールバー付きで、履歴項目をアニメーション表示します。
   @override
   Widget build(BuildContext context) {
     return Scrollbar(

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart
@@ -6,19 +6,18 @@ import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/number_data.dart';
 import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
 
-/// 検索履歴リスト部分のウィジェット。
+/// 検索履歴リストを表示するウィジェット。
 ///
-/// 検索履歴のリストを表示し、履歴項目のタップ時に[onHistoryTap]が呼ばれます。
+/// 検索履歴のリストをAnimatedListでアニメーション付きで表示します。
+/// 履歴が空の場合は「履歴なし」メッセージを表示します。
 class SearchHistoryListView extends ConsumerStatefulWidget {
-  /// 検索履歴リストのコンストラクタ。
+  /// [onHistoryTap]コールバックを受け取るコンストラクタ。
   ///
-  /// [onHistoryTap]は履歴の文字列を引数に取り、タップ時に呼び出されます。
+  /// 検索履歴項目がタップされた際に呼ばれるコールバックを指定します。
   const SearchHistoryListView({required this.onHistoryTap, super.key});
 
-  /// 検索履歴の項目がタップされたときに呼ばれるコールバック。
+  /// 検索履歴項目がタップされたときに呼ばれるコールバック。
   final void Function(String) onHistoryTap;
-
-  /// Stateを生成します。
   @override
   ConsumerState<SearchHistoryListView> createState() =>
       _SearchHistoryListViewState();
@@ -35,24 +34,42 @@ class SearchHistoryListView extends ConsumerStatefulWidget {
   }
 }
 
-/// 検索履歴リストの状態管理クラス。
+/// 検索履歴リストの状態を管理するStateクラス。
 ///
-/// スクロールコントローラの管理や、履歴データの監視・表示を行います。
+/// AnimatedListの状態管理や履歴リストの同期処理を行います。
 class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
+  /// スクロール位置を管理するコントローラー。
   final _scrollController = ScrollController();
-  final _listKey = GlobalKey<AnimatedListState>();
-  List<String> _oldHistory = [];
 
+  /// AnimatedListの状態を管理するキー。
+  final _listKey = GlobalKey<AnimatedListState>();
+
+  /// 内部で保持する履歴リスト。
+  List<String> _internalList = [];
+
+  /// 初回ビルドかどうかのフラグ。
+  var _firstBuild = true;
+
+  /// アニメーションの継続時間。
   static const _animationDuration = Duration(milliseconds: 150);
 
   @override
   void dispose() {
-    super.dispose();
     _scrollController.dispose();
+    super.dispose();
   }
 
+  /// 検索履歴リストのUIを構築します。
+  ///
+  /// RiverpodのProviderから履歴を監視し、AnimatedListで表示します。
   @override
   Widget build(BuildContext context) {
+    // 検索履歴のProviderを監視し、更新があればAnimatedListを同期します。
+    ref.listen(searchHistoryProvider, (_, history) {
+      if (history is AsyncData<List<String>>) {
+        _updateAnimatedList(history.requireValue);
+      }
+    });
     final historyAsync = ref.watch(searchHistoryProvider);
     return Expanded(
       child: historyAsync.when(
@@ -60,12 +77,7 @@ class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             _updateAnimatedList(history);
           });
-          // AnimatedListStateがまだ取得できていない場合は、_oldHistoryをhistoryで初期化
-          if (_listKey.currentState == null &&
-              _oldHistory.length != history.length) {
-            _oldHistory = List.from(history);
-          }
-          if (_oldHistory.isEmpty) {
+          if (_internalList.isEmpty) {
             return Center(
               child: Text(
                 AppLocalizations.of(context)?.noSearchHistory ??
@@ -80,7 +92,7 @@ class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
             child: AnimatedList(
               key: _listKey,
               controller: _scrollController,
-              initialItemCount: _oldHistory.length,
+              initialItemCount: _internalList.length,
               itemBuilder: (context, index, animation) {
                 return SizeTransition(
                   sizeFactor: CurvedAnimation(
@@ -89,7 +101,7 @@ class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
                   ),
                   child: _SearchHistoryListItem(
                     index: index,
-                    value: _oldHistory[index],
+                    value: _internalList[index],
                     onHistoryTap: widget.onHistoryTap,
                   ),
                 );
@@ -103,18 +115,24 @@ class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
     );
   }
 
-  void _updateAnimatedList(List<String> newHistory) {
+  /// AnimatedListの内容を新しい履歴リスト[newList]に同期します。
+  ///
+  /// 初回ビルド時はリストをそのままコピーし、
+  /// 2回目以降は削除・追加のアニメーションを適用してリストを更新します。
+  void _updateAnimatedList(List<String> newList) {
     final listState = _listKey.currentState;
-    if (listState == null) {
-      _oldHistory = List.from(newHistory);
+    if (_firstBuild) {
+      _internalList = List.from(newList);
+      _firstBuild = false;
       return;
     }
-    // 差分検出
-    final old = List<String>.from(_oldHistory);
-    final newList = List<String>.from(newHistory);
-    // 削除
-    for (var i = old.length - 1; i >= 0; i--) {
-      if (!newList.contains(old[i])) {
+    if (listState == null) {
+      return;
+    }
+    // 削除（降順）
+    for (var i = _internalList.length - 1; i >= 0; i--) {
+      if (!newList.contains(_internalList[i])) {
+        final removed = _internalList.removeAt(i);
         listState.removeItem(
           i,
           (context, animation) => SizeTransition(
@@ -122,39 +140,19 @@ class _SearchHistoryListViewState extends ConsumerState<SearchHistoryListView> {
               parent: animation,
               curve: Curves.easeInOut,
             ),
-            child: _SearchHistoryListItem(
-              index: i,
-              value: old[i],
-              onHistoryTap: widget.onHistoryTap,
-            ),
+            child: ListTile(title: Text(removed)),
           ),
           duration: _animationDuration,
         );
-        _oldHistory.removeAt(i);
       }
     }
-    // 追加
+    // 追加（昇順）
     for (var i = 0; i < newList.length; i++) {
-      if (i >= _oldHistory.length || _oldHistory[i] != newList[i]) {
-        _oldHistory.insert(i, newList[i]);
+      if (i >= _internalList.length || _internalList[i] != newList[i]) {
+        _internalList.insert(i, newList[i]);
         listState.insertItem(i, duration: _animationDuration);
       }
     }
-    // 長さ調整
-    if (_oldHistory.length > newList.length) {
-      _oldHistory = List.from(newList);
-    }
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(
-      ObjectFlagProperty<void Function(String)>.has(
-        'onHistoryTap',
-        widget.onHistoryTap,
-      ),
-    );
   }
 }
 

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+/// 検索履歴リストの状態とAnimatedListの操作を管理するViewModel。
+///
+/// スクロールコントローラーやリストキー、内部リスト、
+/// AnimatedListの同期ロジックを保持します。
+class SearchHistoryListViewModel extends ChangeNotifier {
+  /// スクロール位置を管理するコントローラー。
+  final scrollController = ScrollController();
+
+  /// AnimatedListの状態を管理するキー。
+  final listKey = GlobalKey<AnimatedListState>();
+
+  /// 内部で保持する履歴リスト。
+  List<String> internalList = [];
+
+  /// 初回ビルドかどうかのフラグ。
+  var _firstBuild = true;
+  bool get firstBuild => _firstBuild;
+
+  /// アニメーションの継続時間。
+  static const animationDuration = Duration(milliseconds: 150);
+
+  /// AnimatedListの内容を新しい履歴リスト[newList]に同期します。
+  ///
+  /// 初回ビルド時はリストをそのままコピーし、
+  /// 2回目以降は削除・追加のアニメーションを適用してリストを更新します。
+  void updateAnimatedList(List<String> newList) {
+    final listState = listKey.currentState;
+    if (firstBuild) {
+      internalList = List.from(newList);
+      _firstBuild = false;
+      notifyListeners();
+      return;
+    }
+    if (listState == null) {
+      return;
+    }
+    _deleteItems(newList, listState);
+    _addItems(newList, listState);
+    notifyListeners();
+  }
+
+  void _addItems(List<String> newList, AnimatedListState listState) {
+    for (var i = 0; i < newList.length; i++) {
+      if (i >= internalList.length || internalList[i] != newList[i]) {
+        internalList.insert(i, newList[i]);
+        listState.insertItem(i, duration: animationDuration);
+      }
+    }
+  }
+
+  void _deleteItems(List<String> newList, AnimatedListState listState) {
+    for (var i = internalList.length - 1; i >= 0; i--) {
+      if (!newList.contains(internalList[i])) {
+        final removed = internalList.removeAt(i);
+        listState.removeItem(
+          i,
+          (context, animation) => SizeTransition(
+            sizeFactor: CurvedAnimation(
+              parent: animation,
+              curve: Curves.easeInOut,
+            ),
+            child: ListTile(title: Text(removed)),
+          ),
+          duration: animationDuration,
+        );
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart
@@ -41,6 +41,9 @@ class SearchHistoryListViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// [newList]に含まれる要素をinternalListに追加し、AnimatedListに挿入アニメーションを適用します。
+  ///
+  /// newListの各要素をinternalListと比較し、異なる場合は該当位置に挿入します。
   void _addItems(List<String> newList, AnimatedListState listState) {
     for (var i = 0; i < newList.length; i++) {
       if (i >= internalList.length || internalList[i] != newList[i]) {
@@ -50,6 +53,9 @@ class SearchHistoryListViewModel extends ChangeNotifier {
     }
   }
 
+  /// internalListから[newList]に含まれない要素を削除し、AnimatedListに削除アニメーションを適用します。
+  ///
+  /// internalListを後ろから走査し、newListに存在しない要素をAnimatedListからアニメーション付きで削除します。
   void _deleteItems(List<String> newList, AnimatedListState listState) {
     for (var i = internalList.length - 1; i >= 0; i--) {
       if (!newList.contains(internalList[i])) {

--- a/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart
+++ b/lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart';
 
 /// 検索履歴リストの状態とAnimatedListの操作を管理するViewModel。
 ///
@@ -65,9 +66,13 @@ class SearchHistoryListViewModel extends ChangeNotifier {
           (context, animation) => SizeTransition(
             sizeFactor: CurvedAnimation(
               parent: animation,
-              curve: Curves.easeInOut,
+              curve: Curves.decelerate,
             ),
-            child: ListTile(title: Text(removed)),
+            child: SearchHistoryListItem(
+              index: i,
+              value: removed,
+              onHistoryTap: (value) {},
+            ),
           ),
           duration: animationDuration,
         );

--- a/lib/features/repository_search/presentation/provider/search_result_ui_state_provider.g.dart
+++ b/lib/features/repository_search/presentation/provider/search_result_ui_state_provider.g.dart
@@ -7,7 +7,7 @@ part of 'search_result_ui_state_provider.dart';
 // **************************************************************************
 
 String _$searchResultUIStateHash() =>
-    r'44b0885cc2b77486c95e8441daa695d782765a38';
+    r'9a709fb970f92fdca62b8430289f21fa33c58f0e';
 
 /// See also [searchResultUIState].
 @ProviderFor(searchResultUIState)

--- a/test/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart';
+
+class MockAnimatedListState extends Mock implements AnimatedListState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      'MockAnimatedListState';
+}
+
+class TestableSearchHistoryListViewModel extends ChangeNotifier {
+  List<String> internalList = [];
+  var _firstBuild = true;
+  static const animationDuration = Duration(milliseconds: 150);
+
+  void updateAnimatedListWithState(
+    List<String> newList,
+    AnimatedListState? listState,
+  ) {
+    if (_firstBuild) {
+      internalList = List.from(newList);
+      _firstBuild = false;
+      notifyListeners();
+      return;
+    }
+    if (listState == null) {
+      return;
+    }
+    // 削除
+    for (var i = internalList.length - 1; i >= 0; i--) {
+      if (!newList.contains(internalList[i])) {
+        final removed = internalList.removeAt(i);
+        listState.removeItem(
+          i,
+          (context, animation) => SizeTransition(
+            sizeFactor: CurvedAnimation(
+              parent: animation,
+              curve: Curves.easeInOut,
+            ),
+            child: ListTile(title: Text(removed)),
+          ),
+          duration: animationDuration,
+        );
+      }
+    }
+    // 追加
+    for (var i = 0; i < newList.length; i++) {
+      if (i >= internalList.length || internalList[i] != newList[i]) {
+        internalList.insert(i, newList[i]);
+        listState.insertItem(i, duration: animationDuration);
+      }
+    }
+    notifyListeners();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('SearchHistoryListViewModel', () {
+    late SearchHistoryListViewModel viewModel;
+    setUp(() {
+      viewModel = SearchHistoryListViewModel();
+    });
+
+    test('初回ビルド時はinternalListがコピーされ、firstBuildがfalseになる', () {
+      final list = ['a', 'b', 'c'];
+      var notified = false;
+      viewModel.addListener(() => notified = true);
+      viewModel.updateAnimatedList(list);
+      expect(viewModel.internalList, equals(list));
+      expect(viewModel.firstBuild, isFalse);
+      expect(notified, isTrue);
+    });
+
+    test('2回目以降はinternalListの追加・削除が正しく行われる', () {
+      final initial = ['a', 'b', 'c'];
+      final updated = ['b', 'c', 'd'];
+      final testViewModel = TestableSearchHistoryListViewModel();
+      testViewModel.updateAnimatedListWithState(
+        initial,
+        MockAnimatedListState(),
+      ); // 初回
+      final mockListState = MockAnimatedListState();
+      testViewModel.updateAnimatedListWithState(updated, mockListState);
+      // removeItemの呼び出し検証は省略
+      verify(
+        mockListState.insertItem(
+          2,
+          duration: TestableSearchHistoryListViewModel.animationDuration,
+        ),
+      ).called(1);
+      expect(testViewModel.internalList, equals(updated));
+    });
+
+    test('listStateがnullの場合は何もしない', () {
+      final initial = ['a'];
+      final updated = ['b'];
+      final testViewModel = TestableSearchHistoryListViewModel();
+      testViewModel.updateAnimatedListWithState(
+        initial,
+        MockAnimatedListState(),
+      ); // 初回
+      testViewModel.updateAnimatedListWithState(updated, null);
+      expect(testViewModel.internalList, equals(initial));
+    });
+
+    test('disposeでscrollControllerが破棄される', () {
+      viewModel.dispose();
+      expect(
+        () => viewModel.scrollController.position,
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/test/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart';
+import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/provider/search_history_provider.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+
+import '../../../../../../mock/mock_shared_preferences_async_platform.dart';
+
+void main() {
+  group('SearchHistoryListView', () {
+    setUp(() {
+      // SharedPreferencesのモックを初期化
+      SharedPreferencesAsyncPlatform.instance =
+          MockSharedPreferencesAsyncPlatform();
+    });
+
+    testWidgets('履歴が空の場合は「履歴なし」メッセージが表示される', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchHistoryProvider.overrideWith(
+              () => TestSearchHistory(<String>[]),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+            ],
+            home: Scaffold(
+              body: Column(
+                children: [
+                  SearchHistoryListView(
+                    onHistoryTap: (_) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text(WordingData.noSearchHistory), findsOneWidget);
+    });
+
+    testWidgets('履歴がある場合はリストが表示される', (tester) async {
+      const history = ['Flutter', 'Dart'];
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchHistoryProvider.overrideWith(
+              () => TestSearchHistory(history),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  SearchHistoryListView(
+                    onHistoryTap: (_) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      for (final item in history) {
+        expect(find.text(item), findsOneWidget);
+      }
+    });
+
+    testWidgets('履歴項目をタップするとonHistoryTapが呼ばれる', (tester) async {
+      const history = ['Flutter'];
+      String? tapped;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchHistoryProvider.overrideWith(
+              () => TestSearchHistory(history),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  SearchHistoryListView(
+                    onHistoryTap: (value) => tapped = value,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Flutter'));
+      expect(tapped, 'Flutter');
+    });
+  });
+}
+
+// テスト用の検索履歴管理クラス
+class TestSearchHistory extends SearchHistory {
+  TestSearchHistory([List<String>? initial]) : _history = initial ?? [];
+  List<String> _history;
+
+  @override
+  Future<List<String>> build() async {
+    return _history;
+  }
+
+  @override
+  Future<void> add(String keyword) async {
+    if (keyword.isEmpty) {
+      return;
+    }
+    _history = [keyword, ..._history.where((e) => e != keyword)];
+    _history = _history.take(10).toList();
+    state = AsyncData(_history);
+  }
+
+  @override
+  Future<void> clear() async {
+    _history = [];
+    state = const AsyncData([]);
+  }
+
+  @override
+  Future<void> removeTo(String data) async {
+    _history = _history.where((e) => e != data).toList();
+    state = AsyncData(_history);
+  }
+}


### PR DESCRIPTION
## 概要

検索履歴リスト表示部分にアニメーション付きのリスト表示（AnimatedList）を導入し、UI/UXを向上させました。

## 関連Issue

#114 

## 変更内容

### 主な内容

- 検索履歴リスト表示のアニメーション対応
  - `lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view.dart` 
    - 検索履歴リストビュー表示を行う（新規）
  - `lib/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model.dart`
    - 検索履歴リストビューの表示状態管理を行う（新規）
  - `lib/features/repository_search/presentation/page/repository_search/widget/custom_drawer.dart`
    - 既存の履歴リストWidgetを新Widgetに差し替え

- Providerの自動生成ファイルの更新
  - `lib/features/repository_search/presentation/provider/search_result_ui_state_provider.g.dart`

- テストコードの追加・拡充
  - `test/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_model_test.dart`（新規追加）
  - `test/features/repository_search/presentation/page/repository_search/widget/search_history_list_view_test.dart`（新規追加）

## 動作確認内容

| before | after |
| - | - |
|  |  |

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->