### PR TITLE
検索クエリのバリデーション機能を追加した。

### DIFF
--- a/lib/features/repository_search/presentation/provider/search_query_validator_provider.dart
+++ b/lib/features/repository_search/presentation/provider/search_query_validator_provider.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:yumemi_flutter_engineer_codecheck/l10n/app_localizations.dart';
+import 'package:yumemi_flutter_engineer_codecheck/static/wording_data.dart';
+
+part 'search_query_validator_provider.g.dart';
+
+@riverpod
+SearchQueryValidateStrings? Function(String?) searchQueryValidator(Ref ref) {
+  return (value) {
+    // 空文字は無効
+    if (value == null || value.trim().isEmpty) {
+      return SearchQueryValidateStrings.inputKeyword;
+    }
+
+    // 256文字制限（修飾子や演算子を除く）
+    // ここではシンプルに全体長でチェック
+    if (value.length > 256) {
+      // contextが使えないため、WordingDataのみ利用
+      return SearchQueryValidateStrings.searchQueryLength;
+    }
+
+    // AND/OR/NOT演算子の合計が5個を超えていないか
+    final operatorRegExp = RegExp(r'\b(AND|OR|NOT)\b', caseSensitive: false);
+    final operatorCount = operatorRegExp.allMatches(value).length;
+    if (operatorCount > 5) {
+      return SearchQueryValidateStrings.searchQueryOperator;
+    }
+
+    // 正常な場合はnullを返す
+    return null;
+  };
+}
+
+enum SearchQueryValidateStrings {
+  inputKeyword(),
+  searchQueryLength(),
+  searchQueryOperator();
+
+  const SearchQueryValidateStrings();
+
+  String messageVia(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    if (l10n == null) {
+      // ローカライズが利用できない場合はデフォルトのメッセージを返す
+      return switch (this) {
+        SearchQueryValidateStrings.inputKeyword => WordingData.inputKeyword,
+        SearchQueryValidateStrings.searchQueryLength =>
+          WordingData.searchQueryLength,
+        SearchQueryValidateStrings.searchQueryOperator =>
+          WordingData.searchQueryOperator,
+      };
+    }
+    return switch (this) {
+      SearchQueryValidateStrings.inputKeyword => l10n.inputKeyword,
+      SearchQueryValidateStrings.searchQueryLength => l10n.searchQueryLength,
+      SearchQueryValidateStrings.searchQueryOperator =>
+        l10n.searchQueryOperator,
+    };
+  }
+}

--- a/lib/features/repository_search/presentation/provider/search_query_validator_provider.g.dart
+++ b/lib/features/repository_search/presentation/provider/search_query_validator_provider.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_query_validator_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$searchQueryValidatorHash() =>
+    r'547a14cbf3ccd1eb29083d0b3123511bf509853d';
+
+/// See also [searchQueryValidator].
+@ProviderFor(searchQueryValidator)
+final searchQueryValidatorProvider =
+    AutoDisposeProvider<SearchQueryValidateStrings? Function(String?)>.internal(
+      searchQueryValidator,
+      name: r'searchQueryValidatorProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$searchQueryValidatorHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef SearchQueryValidatorRef =
+    AutoDisposeProviderRef<SearchQueryValidateStrings? Function(String?)>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -74,5 +74,13 @@
   "noRepository": "No repositories found.",
   "@noRepository": {
     "description": "Message shown when there is no repository found."
+  },
+  "searchQueryLength": "Search query must be 256 characters or less.",
+  "@searchQueryLength": {
+    "description": "Error message for search query length."
+  },
+  "searchQueryOperator": "Up to 5 AND/OR/NOT operators are allowed.",
+  "@searchQueryOperator": {
+    "description": "Error message for AND/OR/NOT operator count."
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -17,5 +17,7 @@
   "clearHistory": "検索履歴をクリアします",
   "searchHistory": "検索履歴",
   "noSearchHistory": "検索履歴はありません。",
-  "noRepository": "該当するリポジトリはありません。"
+  "noRepository": "該当するリポジトリはありません。",
+  "searchQueryLength": "検索クエリは256文字以内で入力してください",
+  "searchQueryOperator": "AND/OR/NOT演算子は合計5個までです"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -211,6 +211,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No repositories found.'**
   String get noRepository;
+
+  /// Error message for search query length.
+  ///
+  /// In en, this message translates to:
+  /// **'Search query must be 256 characters or less.'**
+  String get searchQueryLength;
+
+  /// Error message for AND/OR/NOT operator count.
+  ///
+  /// In en, this message translates to:
+  /// **'Up to 5 AND/OR/NOT operators are allowed.'**
+  String get searchQueryOperator;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -64,4 +64,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get noRepository => 'No repositories found.';
+
+  @override
+  String get searchQueryLength =>
+      'Search query must be 256 characters or less.';
+
+  @override
+  String get searchQueryOperator => 'Up to 5 AND/OR/NOT operators are allowed.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -64,4 +64,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get noRepository => '該当するリポジトリはありません。';
+
+  @override
+  String get searchQueryLength => '検索クエリは256文字以内で入力してください';
+
+  @override
+  String get searchQueryOperator => 'AND/OR/NOT演算子は合計5個までです';
 }

--- a/lib/l10n/strings.csv
+++ b/lib/l10n/strings.csv
@@ -18,3 +18,5 @@ clearHistory,Tooltip for clearing search history.,Clear search history,検索履
 searchHistory,The title for the search history section.,Search History,検索履歴
 noSearchHistory,Message shown when there is no search history.,No search history.,検索履歴はありません。
 noRepository,Message shown when there is no repository found.,No repositories found.,該当するリポジトリはありません。
+searchQueryLength,Error message for search query length.,Search query must be 256 characters or less.,検索クエリは256文字以内で入力してください
+searchQueryOperator,Error message for AND/OR/NOT operator count.,Up to 5 AND/OR/NOT operators are allowed.,AND/OR/NOT演算子は合計5個までです

--- a/lib/static/wording_data.dart
+++ b/lib/static/wording_data.dart
@@ -64,4 +64,12 @@ class WordingData {
 
   /// 検索結果が空の場合の表示用ラベル。該当するリポジトリがない場合に利用されます。
   static const noRepository = 'No repositories found.';
+
+  /// 検索クエリが256文字を超えた場合のエラーメッセージ。
+  static const searchQueryLength =
+      'Search query must be 256 characters or less.';
+
+  /// AND/OR/NOT演算子が合計5個を超えた場合のエラーメッセージ。
+  static const searchQueryOperator =
+      'Up to 5 AND/OR/NOT operators are allowed.';
 }

--- a/test/features/repository_search/presentation/page/repository_search/widget/search_text_field_test.dart
+++ b/test/features/repository_search/presentation/page/repository_search/widget/search_text_field_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yumemi_flutter_engineer_codecheck/features/repository_search/presentation/page/repository_search/widget/search_text_field.dart';
 
@@ -13,11 +14,13 @@ void main() {
     });
     testWidgets('labelTextが表示される', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SearchTextField(
-              controller: controller,
-              labelText: '検索',
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SearchTextField(
+                controller: controller,
+                labelText: '検索',
+              ),
             ),
           ),
         ),
@@ -28,11 +31,13 @@ void main() {
     testWidgets('onChangedが呼ばれる', (tester) async {
       String? value;
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SearchTextField(
-              controller: controller,
-              onChanged: (v) => value = v,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SearchTextField(
+                controller: controller,
+                onChanged: (v) => value = v,
+              ),
             ),
           ),
         ),
@@ -44,25 +49,32 @@ void main() {
     testWidgets('onCancelButtonPressedが呼ばれる', (tester) async {
       var pressed = false;
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SearchTextField(
-              controller: controller,
-              onCancelButtonPressed: () => pressed = true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SearchTextField(
+                controller: controller,
+                onCancelButtonPressed: () => pressed = true,
+              ),
             ),
           ),
         ),
       );
+      // テキストを入力してキャンセルボタンを表示
+      await tester.enterText(find.byType(TextField), 'a');
+      await tester.pump();
       await tester.tap(find.byIcon(Icons.cancel));
       expect(pressed, isTrue);
     });
 
     testWidgets('テキスト入力時にTextFieldに表示される', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SearchTextField(
-              controller: controller,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SearchTextField(
+                controller: controller,
+              ),
             ),
           ),
         ),
@@ -77,11 +89,13 @@ void main() {
     testWidgets('onSubmittedが呼ばれる', (tester) async {
       String? submittedValue;
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SearchTextField(
-              controller: controller,
-              onSubmitted: (v) => submittedValue = v,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SearchTextField(
+                controller: controller,
+                onSubmitted: (v) => submittedValue = v,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## 概要

検索クエリのバリデーション機能を追加し、エラーメッセージの多言語対応を行いました。これにより、検索ボックスでの入力制限やエラー表示が強化され、ユーザー体験が向上します。

## 関連Issue

#113 

## 変更内容

### 主な内容

- 検索クエリのバリデーションロジックを新規追加
  - `lib/features/repository_search/presentation/provider/search_query_validator_provider.dart`
  - `lib/features/repository_search/presentation/provider/search_query_validator_provider.g.dart`

- 検索テキストフィールドのバリデーション対応
  - `lib/features/repository_search/presentation/page/repository_search/widget/search_text_field.dart`
    - `StatelessWidget` → `HookConsumerWidget` へ変更
    - Riverpodによるバリデーション導入
    - 入力長・演算子数の制限とエラーメッセージ表示

- 多言語エラーメッセージの追加・対応
  - `lib/l10n/app_en.arb`
  - `lib/l10n/app_ja.arb`
  - `lib/l10n/app_localizations.dart`
  - `lib/l10n/app_localizations_en.dart`
  - `lib/l10n/app_localizations_ja.dart`
  - `lib/l10n/strings.csv`
  - `lib/static/wording_data.dart`

### その他

- Riverpodコード生成ファイルの追加
  - `lib/features/repository_search/presentation/provider/search_query_validator_provider.g.dart`

## 動作確認内容

バリデーションの確認を行なった
- 空白文字だけ入力する
- 256文字以上入力する
- AND/OR/NOT文字列を５階を超えて入力する

## 補足

<!-- レビュワーへの補足事項や注意点があれば記載してください -->