### PR TITLE
CFBundleLocalizationsを追加して、アプリの多言語対応を強化

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ja</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 概要

iOSアプリの多言語対応のため、`Info.plist` にローカライズ設定（英語・日本語）を追加しました。

## 関連Issue

<!-- このまま記して下さい -->

## 変更内容

### 主な内容

- iOSのローカライズ対応
  - `CFBundleLocalizations` キーを追加し、`en`（英語）と`ja`（日本語）をサポート
    - 変更ファイル: ios/Runner/Info.plist

## 動作確認内容

日本語・英語それぞれの環境でテキストフィールドを長押しした時のシステムポップアップが多言語対応されているかをチェックした

## 補足

Androidは素で対応できているようでした。